### PR TITLE
Fix ValueError

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -293,7 +293,9 @@ class CharmProject:
 
         # Create recipes that are missing and/o update recipes that have
         # changes.
-        for recipe_name, state in current['in_config_recipes']:
+        logger.debug('in_config_recipes={}'.format(
+            current['in_config_recipes']))
+        for recipe_name, state in current['in_config_recipes'].items():
             if state['exists'] and state['changed']:
                 # it's an update
                 lp_recipe = state['current_recipe']


### PR DESCRIPTION
Without this fixes, `sync` fails with

```
DEBUG:charmhub_lp_tools.charm_project:in_config_recipes=OrderedDict([('charm-nova-compute-nvidia-vgpu.master.latest', {'exists': False, 'changed': False, 'current_recipe': None, 'updated_recipe': None, 'changes': [], 'build_from': {'recipe_name': 'charm-nova-compute-nvidia-vgpu.master.latest', 'branch_info': {'auto-build': True, 'upload': True, 'recipe-name': '{project}.{branch}.{track}', 'channels': ['latest/stable']}, 'lp_branch': <git_ref at https://api.launchpad.net/devel/~openstack-charmers/charm-nova-compute-nvidia-vgpu/+git/charm-nova-compute-nvidia-vgpu/+ref/master>, 'lp_team': <team at https://api.launchpad.net/devel/~openstack-charmers>, 'lp_project': <project at https://api.launchpad.net/devel/charm-nova-compute-nvidia-vgpu>, 'store_name': 'nova-compute-nvidia-vgpu', 'channels': ['latest/stable']}})])
ERROR:charmhub_lp_tools.main:Unexpected error: too many values to unpack (expected 2)
Traceback (most recent call last):
  File "/usr/local/bin/charmhub-lp-tool", line 8, in <module>
    sys.exit(cli_main())
  File "/usr/local/lib/python3.9/dist-packages/charmhub_lp_tools/main.py", line 381, in cli_main
    main()
  File "/usr/local/lib/python3.9/dist-packages/charmhub_lp_tools/main.py", line 375, in main
    args.func(args, gc)
  File "/usr/local/lib/python3.9/dist-packages/charmhub_lp_tools/main.py", line 337, in sync_main
    charm_project.ensure_charm_recipes()
  File "/usr/local/lib/python3.9/dist-packages/charmhub_lp_tools/charm_project.py", line 296, in ensure_charm_recipes
    for recipe_name, state in current['in_config_recipes']:
ValueError: too many values to unpack (expected 2)
```