### PR TITLE
Add support to build a snap.

### DIFF
--- a/.github/workflows/snapcraft.yaml
+++ b/.github/workflows/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: Snapcraft
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: build
+    - id: run-help
+      run: |
+        sudo snap install --dangerous ${{ steps.build.outputs.snap }}
+        charmhub-lp-tool --help
+    - id: publish
+      if: ${{ github.event_name == 'push' }}
+      uses: snapcore/action-publish@v1
+      with:
+        # See: https://github.com/snapcore/action-publish#store-login
+        store_login: ${{ secrets.STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# snaps build
+*.snap

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ launchpadlib
 prettytable
 humanize
 backports.zoneinfo; python_version < '3.9'
+SecretStorage  # LP: #1923727

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,42 @@
+name: charmhub-lp-tool
+base: core20
+version: git
+summary: Tools to configure and manage repositories and launchpad builders.
+description: |
+  This repository provides the `charmhub-lp-tool` command that provides the
+  ability to configure and manage the launchpad builders, repositories and
+  branches in repositories.
+
+  The commands are:
+
+    * show -> display the current config.
+    * list -> show a list of the charms configured in the supplied config.
+    * diff -> show the current config and a diff to what is asked for.
+    * config -> show the asked for config
+    * sync -> sync the asked for config to the charm in the form of recipes.
+
+  After installation of the snap connect the password-manager-service
+  interface to allow charmhub-lp-tool to store the Launchpad's access token in
+  the keyring.
+
+grade: stable
+confinement: strict
+
+apps:
+  charmhub-lp-tool:
+    command: bin/charmhub-lp-tool
+    plugs:
+      - network
+      - home
+      - password-manager-service  # to allow launchpadlib to store the token in the keyring.
+parts:
+  charmhub-lp-tool:
+    plugin: python
+    source: ./
+    requirements:
+      - ./requirements.txt
+    # stage-packages:
+    #   - python3-cryptography  # required by python3-secretstorage
+    #   - python3-gi  # required by python3-secretstorage
+    #   - python3-cairo  # required by python3-gi
+    #   - python3-secretstorage


### PR DESCRIPTION
This change introduces snapcraft.yaml to produce a snap named
"charmhub-lp-tool". It uses the password-manager-service interface to
allow launchpadlib to store the store the auth token in the keyring (see
LP: #1923727).