### PR TITLE
Add subcommand request-build

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -843,7 +843,10 @@ class CharmProject:
 
         return builds
 
-    def request_build_by_recipe(self, recipe, force, dry_run) -> object:
+    def request_build_by_recipe(self,
+                                recipe: TypeLPObject,
+                                force: bool,
+                                dry_run: bool) -> Optional[TypeLPObject]:
         """Request a build for the recipe.
 
         :param recipe: recipe to request the build for.
@@ -876,7 +879,7 @@ class CharmProject:
 
         return build
 
-    def is_build_valid(self, build) -> bool:
+    def is_build_valid(self, build: TypeLPObject) -> bool:
         """Determine if the build is valid.
 
         A valid build a build that meets the following criteria:
@@ -886,6 +889,9 @@ class CharmProject:
           building)
         - the build state is in any of: 'Failed to build', 'Failed to upload'.
         - the associated recipe is stale.
+
+        :param build: build to check if it is valid.
+        :returns: True if the last build is valid.
         """
         logger.debug(('Recipe can_upload_to_store %s , '
                       'store_upload_revision %s, build state %s, is stale %s'),

--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -351,9 +351,9 @@ class CharmProject:
                 "but are configured as branches for recipes.")
             for branch in current['missing_branches_in_repo']:
                 print(f" - {branch}")
-        any_changes = (any(not(r['exists']) or r['changed']
+        any_changes = (any(not (r['exists']) or r['changed']
                            for r in current['in_config_recipes'].values()))
-        if not(any_changes) and not(current['non_config_recipes']):
+        if not (any_changes) and not (current['non_config_recipes']):
             print("No changes needed.")
             return
 
@@ -373,7 +373,7 @@ class CharmProject:
                     for rpart, battr in state['updated_parts'].items():
                         setattr(lp_recipe, rpart, battr)
                     lp_recipe.lp_save()
-            elif not(state['exists']):
+            elif not (state['exists']):
                 if dry_run:
                     print(f'Would create recipe {recipe_name} (dry_run)')
                 else:
@@ -592,7 +592,7 @@ class CharmProject:
             print(f"{self.name[:35]:35} -- No repo configured!", file=file)
             return
         info = self._calc_recipes_for_repo()
-        any_changes = (any(not(r['exists']) or r['changed']
+        any_changes = (any(not (r['exists']) or r['changed']
                            for r in info['in_config_recipes'].values()))
         change_text = ("Changes required"
                        if any_changes or info['missing_branches_in_repo']
@@ -613,7 +613,7 @@ class CharmProject:
             if any_changes:
                 print(" * recipes that require changes:", file=file)
                 for recipe_name, detail_ in info['in_config_recipes'].items():
-                    if not(detail_['exists']):
+                    if not (detail_['exists']):
                         print(f"    - {recipe_name:35} : Needs creating.",
                               file=file)
                     elif detail_['changed']:
@@ -791,7 +791,7 @@ class CharmProject:
             print(f'Branch is: {branch_path}')
             current_recipe = in_config_recipe['current_recipe']
             if current_recipe is not None:
-                if not(current_recipe.can_upload_to_store) or force:
+                if not (current_recipe.can_upload_to_store) or force:
                     print(f"Doing authorization for recipe: {recipe_name} on "
                           f"branch: {branch_path} for charm: "
                           f"{self.charmhub_name}")

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -159,7 +159,7 @@ def get_group_config_filenames(config_dir: pathlib.Path,
                  for group in project_group_names]
         # validate that the files actually exist
         for file in files:
-            if not(file.exists()):
+            if not (file.exists()):
                 raise FileNotFoundError(
                     f"The group config file '{file}' wasn't found")
     return files
@@ -195,7 +195,7 @@ class GroupConfig:
 
         :param files: the list of files to load config from.
         """
-        assert not(isinstance(files, str)), "param files must not be str"
+        assert not (isinstance(files, str)), "param files must not be str"
         assert isinstance(files, collections.abc.Sequence), \
             "Must pass a list or tuple."
         for file in files:
@@ -233,7 +233,7 @@ class GroupConfig:
     def projects(self, select: Optional[List[str]] = None,
                  ) -> Iterator[CharmProject]:
         """Generator returns a list of projects."""
-        if not(select):
+        if not (select):
             select = None
         for project in self.charm_projects.values():
             if (select is None or
@@ -535,12 +535,12 @@ def sync_main(args: argparse.Namespace,
     if args.git_mirror_only:
         logger.info("Only ensuring mirroring of git repositories.")
     for charm_project in gc.projects(select=args.charms):
-        charm_project.ensure_git_repository(dry_run=not(args.confirmed))
-        if not(args.git_mirror_only):
+        charm_project.ensure_git_repository(dry_run=not (args.confirmed))
+        if not (args.git_mirror_only):
             charm_project.ensure_charm_recipes(
                 args.git_branches,
                 remove_unknown=args.remove_unknown_recipes,
-                dry_run=not(args.confirmed))
+                dry_run=not (args.confirmed))
         print()
 
 
@@ -559,7 +559,7 @@ def delete_main(args: argparse.Namespace,
     if not args.confirmed:
         print("--i-really-mean-it flag not used so this is dry run only.")
     if not args.recipe_name:
-        if not(args.track) and not(args.branch):
+        if not (args.track) and not (args.branch):
             raise AssertionError(
                 "'delete' command: must supply either (track and branch) or "
                 "name parameters.  See --help for command.")
@@ -568,12 +568,12 @@ def delete_main(args: argparse.Namespace,
             if args.recipe_name:
                 charm_project.delete_recipe_by_name(
                     recipe_name=args.recipe_name,
-                    dry_run=not(args.confirmed))
+                    dry_run=not (args.confirmed))
             else:
                 charm_project.delete_recipe_by_branch_and_track(
                     track=args.track,
                     branch=args.branch,
-                    dry_run=not(args.confirmed))
+                    dry_run=not (args.confirmed))
         except KeyError as e:
             logger.warning("Delete failed as recipe not found: charm: %s "
                            " reason: %s", charm_project.name, str(e))


### PR DESCRIPTION
The request-build subcommand will request a new build for a recipe defined in Launchpad, it supports to filter by git branch, by default will do a dry run, passing the parameter --i-really-mean-it will effectively submit the request to Launchpad.

This feature will try to avoid to request not needed build by only submitting new builds when the last build of a recipe meets this criteria:

- it's associated recipe has the attribute can_upload_to_store set to True, but the build has no store_upload_revision set, and the build is not in progress (states: currently build, uploading build or needs building)
- the build state is in any of: 'Failed to build', 'Failed to upload'.
- the associated recipe is stale.

Usage example:

To request a new build of cinder-lvm:

  charmhub-lp-tool -c cinder-lvm request-build -b stable/ussuri \ --i-really-mean-it

To request a new build of nova-compute no matter if the last build was successfull:

  charmhub-lp-tool -c nova-compute request-build -b stable/ussuri \
      --i-really-mean-it --force