### PR TITLE
Add request code import

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,5 +25,25 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+    - name: Test with python ${{ matrix.python-version }}
+      run: tox -e py3
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        target:
+          - pep8
+          # - mypy
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Test with tox ${{ matrix.target }}
+        run: tox -e ${{ matrix.target }}

--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -852,6 +852,8 @@ class CharmProject:
         :param recipe: recipe to request the build for.
         :param force: if True, no checks are made to detect if the build is
                       needed.
+        :param dry_run: if True, the request for building is printed, but not
+                        submitted to Launchpad.
         :returns: the build object or None when no build was requested.
         """
         build = None
@@ -910,6 +912,19 @@ class CharmProject:
             return False
 
         return True
+
+    def request_code_import(self,
+                            dry_run: bool):
+        """Request a new code import on Launchpad.
+
+        :param dry_run: if True, the request for building is printed, but not
+                        submitted to Launchpad.
+        """
+        if dry_run:
+            print(f'Requesting new code import {self.lp_repo} (dry-run)')
+            return
+
+        self.lp_repo.code_import.requestImport()
 
     def _find_recipes(self, branches):
         info = self._calc_recipes_for_repo()

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -467,6 +467,21 @@ def parse_args(config_from_file: FileConfig) -> argparse.Namespace:
               'should really submit the requests to Launchpad.')
     )
     request_build_command.set_defaults(func=request_build)
+    # request-code-import helper
+    request_code_import_command = subparser.add_parser(
+        'request-code-import',
+        help='Request a new code import on Launchpad'
+    )
+    request_code_import_command.add_argument(
+        '--i-really-mean-it',
+        dest='confirmed',
+        action='store_true',
+        default=False,
+        help=('This flag must be supplied to indicate that the operation '
+              'should really submit the requests to Launchpad.')
+    )
+    request_code_import_command.set_defaults(func=request_code_import)
+
     args = parser.parse_args()
     return args
 
@@ -687,6 +702,19 @@ def request_build(args: argparse.Namespace,
     for cp in gc.projects(select=args.charms):
         cp.request_build_by_branch(args.git_branches, args.force,
                                    dry_run=not args.confirmed)
+
+
+def request_code_import(args: argparse.Namespace,
+                        gc: GroupConfig,
+                        ) -> None:
+    """Request a code import on Launchpad.
+
+    :param args: the arguments parsed from the command line.
+    :para gc: The GroupConfig; i.e. all the charms and their config.
+    """
+    for cp in gc.projects(select=args.charms):
+        cp.request_code_import(dry_run=not args.confirmed)
+        print(f'Requested import of {cp}')
 
 
 def setup_logging(loglevel: str) -> None:

--- a/charmhub_lp_tools/tests/test_charm_project.py
+++ b/charmhub_lp_tools/tests/test_charm_project.py
@@ -1,0 +1,40 @@
+import unittest
+import yaml
+
+from unittest import mock
+
+from charmhub_lp_tools import charm_project
+
+
+CHARM_CONFIG_STR = """
+name: Awesome Charm
+charmhub: awesome
+launchpad: charm-awesome
+team: awesome-charmers
+repo: https://github.com/canonical/charm-awesome-operator
+branches:
+  main:
+    channels:
+      - yoga/edge
+      - latest/edge
+  stable/xena:
+    channels:
+      - xena/edge
+"""
+CHARM_CONFIG = yaml.safe_load(CHARM_CONFIG_STR)
+
+
+class TestCharmProject(unittest.TestCase):
+    def setUp(self):
+        self.lpt = mock.MagicMock()
+        self.project = charm_project.CharmProject(CHARM_CONFIG, self.lpt)
+
+    def test_request_code_import(self):
+        self.project.request_code_import(dry_run=False)
+        lp_repo = self.lpt.get_git_repository()
+        lp_repo.code_import.requestImport.assert_called_with()
+
+    def test_request_code_import_dry_run(self):
+        self.project.request_code_import(dry_run=True)
+        lp_repo = self.lpt.get_git_repository()
+        lp_repo.code_import.requestImport.assert_not_called()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 flake8
 mypy
+pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = pep8,py3
-skipsdist = True
+skipsdist = False
 # NOTE: Avoid build/test env pollution by not enabling sitepackages.
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
@@ -23,7 +23,10 @@ install_command =
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/requirements.txt
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+commands = pytest charmhub_lp_tools
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
Add request-code-import
    
The subcommand request-code-import submits a request to Launchpad to
run the import task on the git repository associated to a charm.
    
Usage example:
    
    charmhub-lp-tool -c nova-compute request-code-import \
        --i-really-mean-it
