### PR TITLE
Build the snap only when pushing to main and on PR

### DIFF
--- a/.github/workflows/snapcraft.yaml
+++ b/.github/workflows/snapcraft.yaml
@@ -1,8 +1,10 @@
 name: Snapcraft
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This will make the workflow of skipping pushes to feature branches in the charmhub-lp-tools repository.