### PR TITLE
Validate configuration files against a defined schema.

### DIFF
--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -75,6 +75,8 @@ from .reports import (
     get_supported_report_types,
 )
 from .exceptions import InvalidRiskLevel
+from .schema import config_schema
+
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +202,8 @@ class GroupConfig:
         for file in files:
             with open(file, 'r') as f:
                 group_config = yaml.safe_load(f)
+                # validate the content against the schema
+                config_schema.validate(group_config)
             logger.debug('group_config is: \n%s', pprint.pformat(group_config))
             project_defaults = group_config.get('defaults', {})
             # foo/bar/openstack.yaml -> openstack
@@ -768,6 +772,11 @@ def parse_args(config_from_file: FileConfig) -> argparse.Namespace:
     )
     repair_resource_command.set_defaults(func=repair_resource)
 
+    validate_config_commands = subparser.add_parser(
+        'validate-config',
+        help='Validate the configuration according to the schema.')
+    validate_config_commands.set_defaults(func=validate_config_main)
+
     # finally, parse the args and return them.
     args = parser.parse_args()
     return args
@@ -1142,6 +1151,13 @@ def repair_resource(args: argparse.Namespace,
                                bases=args.bases or [],
                                dry_run=not args.confirmed,
                                retries=args.retries)
+
+
+def validate_config_main(args: argparse.Namespace,
+                         gc: GroupConfig,
+                         ):
+    """Validate configuration files based on the schema"""
+    print("Valid config")
 
 
 def setup_logging(loglevel: str) -> None:

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -1157,7 +1157,11 @@ def validate_config_main(args: argparse.Namespace,
                          gc: GroupConfig,
                          ):
     """Validate configuration files based on the schema"""
-    print("Valid config")
+    # This subcommand is a NOOP, if the execution reached to this point it
+    # means the configuration was loaded successfully and validated correctly
+    # by the schema, so there is no need do anything else than inform the user
+    # the configuration is valid.
+    print("The configuration is valid according to the schema.")
 
 
 def setup_logging(loglevel: str) -> None:

--- a/charmhub_lp_tools/schema.py
+++ b/charmhub_lp_tools/schema.py
@@ -1,0 +1,36 @@
+from schema import (
+    Optional,
+    Regex,
+    Schema,
+)
+
+_CHARMHUB_NAME = Regex(r'^[a-z][a-z0-9_\-]+$')
+_LP_NAME = Regex(r'^[a-z][a-z0-9_\-]+$')
+
+
+config_schema = Schema({
+    "defaults": {
+        "team": str,
+        Optional("branches"): {
+            str: {
+                Optional("build-channels"): dict,
+                Optional("channels"): [str],
+                Optional("enabled", default=True): bool,
+            },
+        },
+    },
+    "projects": [{
+        "name": str,
+        "charmhub": _CHARMHUB_NAME,
+        "launchpad": _LP_NAME,
+        "repository": str,
+        Optional("team"): str,
+        Optional("branches"): {
+            str: {
+                "build-channels": dict,
+                "channels": [str],
+                Optional("enabled", default=True): bool,
+            },
+        },
+    }],
+})

--- a/charmhub_lp_tools/tests/test_schema.py
+++ b/charmhub_lp_tools/tests/test_schema.py
@@ -1,0 +1,65 @@
+import unittest
+
+import yaml
+
+from charmhub_lp_tools import schema
+
+
+INVALID_CONFIG = """
+defaults:
+  branches: {}
+"""
+
+VALID_CONFIGS = [
+    """
+defaults:
+  team: openstack-charmers
+  branches:
+    master:
+      build-channels:
+        charmcraft: "1.7/stable"
+      channels:
+        - latest/edge
+    stable/queens:
+      enabled: False
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - queens/edge
+projects:
+  - name: OpenStack Aodh Charm
+    charmhub: aodh
+    launchpad: charm-aodh
+    repository: https://opendev.org/openstack/charm-aodh.git
+
+  - name: OpenStack Barbican Vault Charm
+    charmhub: barbican-vault
+    launchpad: charm-barbican-vault
+    repository: https://opendev.org/openstack/charm-barbican-vault.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "1.7/stable"
+        channels:
+          - latest/edge
+      stable/rocky:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - rocky/edge
+    """,
+]
+
+
+class TestConfigSchema(unittest.TestCase):
+    def test_valid_config_file(self):
+
+        for fixture in VALID_CONFIGS:
+            data = yaml.safe_load(fixture)
+            self.assertTrue(schema.config_schema.is_valid(data),
+                            schema.config_schema.validate(data))
+
+    def test_invalid_config_file(self):
+        data = yaml.safe_load(INVALID_CONFIG)
+        self.assertFalse(schema.config_schema.is_valid(data))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Jinja2
 jinja2-humanize-extension
 requests
 requests-cache
+schema


### PR DESCRIPTION
Introduce the use of the 'schema' library and define the schema that charmhub-lp-tool expepects.

This helps to introduce a formal format and avoid silent typos.