### PR TITLE
Migrate build system to pbr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["pbr>=5.7.0", "setuptools>=36.6.0"]
+build-backend = "pbr.build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,30 @@
 [metadata]
 name = charmhub-lp-tools
-version = 0.0.1.dev1
+author = OpenStack Charmers
+author_email = openstack-charmers@lists.launchpad.net
+summary = Tools to configure and manage repositories and Launchpad builders.
+description_file = README.md
+description_content_type = text/markdown; charset=UTF-8
+home_page = https://github.com/openstack-charmers/charmhub-lp-tools
+project_urls =
+    Bug Tracker = https://github.com/openstack-charmers/charmhub-lp-tools/issues
+    Source Code = https://github.com/openstack-charmers/charmhub-lp-tools
+license = Apache-2
+classifier =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python
+keywords =
+    ci
+    launchpad
 
-[options]
+[files]
 packages = charmhub_lp_tools
-install_requires =
-    ruamel.yaml
-    theblues
-    libcharmstore
+
+[entry_points]
+console_scripts =
+    charmhub-lp-tool = charmhub_lp_tools.main:cli_main

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
+#!/usr/bin/env python
+#
 # Copyright 2021 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,82 +17,9 @@
 
 """Module used to setup the zaza framework."""
 
-import os
-import sys
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-
-version = "0.0.1.dev1"
-install_require = [
-    'ruamel.yaml',
-    'theblues',
-    'libcharmstore',
-    'launchpadlib',
-]
-
-tests_require = [
-    'tox >= 2.3.1',
-]
-
-
-class Tox(TestCommand):
-    """Tox class."""
-
-    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
-
-    def initialize_options(self):
-        """Initialize options."""
-        TestCommand.initialize_options(self)
-        self.tox_args = None
-
-    def finalize_options(self):
-        """Finalize options."""
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        """Run the tests."""
-        # import here, cause outside the eggs aren't loaded
-        import tox
-        import shlex
-        args = self.tox_args
-        # remove the 'test' arg from argv as tox passes it to ostestr which
-        # breaks it.
-        sys.argv.pop()
-        if args:
-            args = shlex.split(self.tox_args)
-        errno = tox.cmdline(args=args)
-        sys.exit(errno)
-
-
-if sys.argv[-1] == 'publish':
-    os.system("python setup.py sdist upload")
-    os.system("python setup.py bdist_wheel upload")
-    sys.exit()
-
-
-if sys.argv[-1] == 'tag':
-    os.system("git tag -a %s -m 'version %s'" % (version, version))
-    os.system("git push --tags")
-    sys.exit()
-
+from setuptools import setup
 
 setup(
-    entry_points={
-        'console_scripts': [
-            'charmhub-lp-tool = charmhub_lp_tools.main:cli_main',
-        ]
-    },
-    license='Apache-2.0: http://www.apache.org/licenses/LICENSE-2.0',
-    packages=find_packages(exclude=["unit_tests"]),
-    zip_safe=False,
-    cmdclass={'test': Tox},
-    install_requires=install_require,
-    include_package_data=True,
-    package_data={'charmhub_lp_tools': ['templates/*.j2']},
-    extras_require={
-        'testing': tests_require,
-    },
-    tests_require=tests_require,
+    setup_requires=['pbr'],
+    pbr=True,
 )


### PR DESCRIPTION
pbr allows to use re-use well known files like requirements.txt and avoid keeping the list of dependencies in two different places, among other goodies.