### PR TITLE
Add osci-sync subcommand

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -603,6 +603,7 @@ class CharmProject:
         self.charmhub_name: str = config.get('charmhub')  # type: ignore
         self.launchpad_project: str = config.get('launchpad')  # type: ignore
         self._lp_project = None
+        self._lp_recipes = None  # type: Dict[str, TypeLPObject]
         self.repository: str = config.get('repository')  # type: ignore
         self.project_group: str = config.get('project_group')  # type: ignore
         self._lp_repo = None
@@ -726,6 +727,16 @@ class CharmProject:
         self._lp_repo = self.lpt.get_git_repository(
             self.lp_team, self.lp_project)
         return self._lp_repo
+
+    @property
+    def lp_recipes(self) -> TypeLPObject:
+        """Get all the recipes defined in Launchpad."""
+        if not self._lp_recipes:
+            recipes = self.lpt.get_charm_recipes(self.lp_team,
+                                                 self.lp_project)
+            self._lp_recipes = {r.name: r for r in recipes}
+
+        return self._lp_recipes
 
     def ensure_git_repository(self,
                               dry_run: bool = True
@@ -910,6 +921,8 @@ class CharmProject:
                         project=self.lp_project,
                         store_name=self.charmhub_name,
                         channels=build_from['channels'])
+                    # clear cached list of recipes
+                    self._lp_recipes = None
                     print('done')
 
             else:

--- a/charmhub_lp_tools/constants.py
+++ b/charmhub_lp_tools/constants.py
@@ -11,3 +11,10 @@ class Risk(Enum):
 
 LIST_OF_RISKS = [x.value for x in list(Risk)]
 PROGRAM_NAME = 'openstack-charm-tools'
+OSCI_YAML = 'osci.yaml'
+DEFAULT_CHARMCRAFT_CHANNEL = '1.5/stable'
+
+# tuple with LP auto build channel key and osci.yaml vars key
+LIST_AUTO_BUILD_CHANNELS = [
+    ('charmcraft', 'charmcraft_channel', DEFAULT_CHARMCRAFT_CHANNEL),
+]

--- a/charmhub_lp_tools/exceptions.py
+++ b/charmhub_lp_tools/exceptions.py
@@ -11,4 +11,8 @@ class BranchNotFound(Exception):
 
 
 class CharmNameNotFound(Exception):
-    """Charm name not found declared in osci.yaml"""
+    """Charm name not found."""
+
+
+class ProjectVarsNotFound(Exception):
+    """project.vars section not found."""

--- a/charmhub_lp_tools/exceptions.py
+++ b/charmhub_lp_tools/exceptions.py
@@ -4,3 +4,11 @@ class CharmcraftError504(Exception):
 
 class InvalidRiskLevel(Exception):
     """Invalid risk level."""
+
+
+class BranchNotFound(Exception):
+    """Branch not found."""
+
+
+class CharmNameNotFound(Exception):
+    """Charm name not found declared in osci.yaml"""

--- a/charmhub_lp_tools/gitutils.py
+++ b/charmhub_lp_tools/gitutils.py
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import configparser
+import logging
+import os
+
+import git
+
+from .exceptions import BranchNotFound
+
+logger = logging.getLogger(__name__)
+
+
+def get_branch_name(git_repo: git.Repo) -> str:
+    """Get branch name from gitreview file.
+
+    The branch name defined in the gitreview file in the 'defaultbranch'
+    section is used, if it's not set, then DEFAULT_BRANCH_MASTER is returned.
+
+    :param git_repo: the repo to operate on.
+    """
+    config = get_gitreview(git_repo)
+    try:
+        return config['gerrit']['defaultbranch']
+    except KeyError:
+        return get_default_branch_name(git_repo)
+
+
+def get_gitreview(git_repo: git.Repo) -> configparser.ConfigParser:
+    """Get gitreview file content.
+
+    :param git_repo: the repo to operate on.
+    :returns: the content of the gitreview file parsed.
+    """
+    config = configparser.ConfigParser()
+    git_root = git_repo.git.rev_parse('--show-toplevel')
+    config.read(os.path.join(git_root, '.gitreview'))
+    return config
+
+
+def get_default_branch_name(git_repo: git.Repo) -> str:
+    """Retrieve the default branch name.
+
+    Identify if the repository uses 'master' or 'main' as default branch name.
+
+    :raises BranchNotFound: when there is no main nor master branches defined
+    :returns: the default branch name
+    """
+    # default branches are something defined by the remote, it can be
+    # retrieved with "git remote show $REMOTE | grep 'HEAD branch' ", although
+    # the issue with it is that we would be at the mercy of the remote's name
+    # which typicall is 'origin', but it's not guaranteed, since in github is
+    # common to use 'upstream', so we'll go for a simpler and more reliable
+    # approach, first to check if 'main' branch exists and return that,
+    # otherwise return 'master', if none of those branches exist locally just
+    # raise an exception.
+    branch_names = [ref.name for ref in git_repo.references]
+    if 'main' in branch_names:
+        return 'main'
+    elif 'master' in branch_names:
+        return 'master'
+    else:
+        msg = "No main nor master branch found, branches found: %s"
+        raise BranchNotFound(msg % branch_names)

--- a/charmhub_lp_tools/gitutils.py
+++ b/charmhub_lp_tools/gitutils.py
@@ -29,9 +29,12 @@ def get_branch_name(git_repo: git.Repo) -> str:
     """Get branch name from gitreview file.
 
     The branch name defined in the gitreview file in the 'defaultbranch'
-    section is used, if it's not set, then DEFAULT_BRANCH_MASTER is returned.
+    section is used, if it's not set, then the default branch name is returned
+    as returned by :func:`get_default_branch_name`
 
     :param git_repo: the repo to operate on.
+    :returns: the base branch name.
+
     """
     config = get_gitreview(git_repo)
     try:
@@ -45,6 +48,7 @@ def get_gitreview(git_repo: git.Repo) -> configparser.ConfigParser:
 
     :param git_repo: the repo to operate on.
     :returns: the content of the gitreview file parsed.
+    :raises: FileNotFoundError
     """
     config = configparser.ConfigParser()
     git_root = git_repo.git.rev_parse('--show-toplevel')

--- a/charmhub_lp_tools/group_config.py
+++ b/charmhub_lp_tools/group_config.py
@@ -31,9 +31,11 @@ from typing import (
 from .charm_project import (
     CharmProject,
 )
-from .schema import config_schema
 from .launchpadtools import (
     LaunchpadTools,
+)
+from .schema import (
+    config_schema,
 )
 
 
@@ -54,6 +56,7 @@ class GroupConfig:
                  files: List[pathlib.Path] = None) -> None:
         """Configure the GroupConfig object.
 
+        :param lpt: the launchpad tools object to do things in Launchpad.
         :param files: the list of files to load config from.
         """
         self.lpt = lpt

--- a/charmhub_lp_tools/group_config.py
+++ b/charmhub_lp_tools/group_config.py
@@ -1,0 +1,122 @@
+# Copyright 2023 Canonical
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import logging
+import os
+import pathlib
+import pprint
+
+import yaml
+
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+)
+
+from .charm_project import (
+    CharmProject,
+)
+from .schema import config_schema
+from .launchpadtools import (
+    LaunchpadTools,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class GroupConfig:
+    """Collect together all the config files and build CharmProject objects.
+
+    This collects together the files passed (which define a charm projects
+    config and creates CharmProject objects to ensure git repositories and
+    ensure that the charm builder recipes in launchpad exist with the correct
+    settings.
+    """
+
+    def __init__(self,
+                 lpt: 'LaunchpadTools',
+                 files: List[pathlib.Path] = None) -> None:
+        """Configure the GroupConfig object.
+
+        :param files: the list of files to load config from.
+        """
+        self.lpt = lpt
+        self.charm_projects: Dict[str, 'CharmProject'] = (
+            collections.OrderedDict())
+        if files is not None:
+            self.load_files(files)
+
+    def load_files(self, files: List[pathlib.Path] = None) -> None:
+        """Load the files into the object.
+
+        This loads the files, and configures the projects and then creates
+        CharmProject objects.
+
+        :param files: the list of files to load config from.
+        """
+        assert not (isinstance(files, str)), "param files must not be str"
+        assert isinstance(files, collections.abc.Sequence), \
+            "Must pass a list or tuple."
+        for file in files:
+            with open(file, 'r') as f:
+                group_config = yaml.safe_load(f)
+                # validate the content against the schema
+                config_schema.validate(group_config)
+            logger.debug('group_config is: \n%s', pprint.pformat(group_config))
+            project_defaults = group_config.get('defaults', {})
+            # foo/bar/openstack.yaml -> openstack
+            project_group = os.path.splitext(os.path.basename(file))[0]
+            for project in group_config.get('projects', []):
+                for key, value in project_defaults.items():
+                    project.setdefault(key, value)
+                logger.debug('Loaded project %s', project.get('name'))
+                project['project_group'] = project_group
+                self.add_charm_project(project)
+
+    def add_charm_project(self,
+                          project_config: Dict[str, Any],
+                          merge: bool = False,
+                          ) -> None:
+        """Add a CharmProject object from the project specification dict.
+
+        :param project: the project to add.
+        :param merge: if merge is True, merge/overwrite the existing object.
+        :raises: ValueError if merge is false and the charm project already
+            exists.
+        """
+        name: str = project_config.get('name')  # type: ignore
+        if name in self.charm_projects:
+            if merge:
+                self.charm_projects[name].merge(project_config)
+            else:
+                raise ValueError(
+                    f"Project config for '{name}' already exists.")
+        else:
+            self.charm_projects[name] = CharmProject(project_config, self.lpt)
+
+    def projects(self, select: Optional[List[str]] = None,
+                 ) -> Iterator[CharmProject]:
+        """Generator returns a list of projects."""
+        if not (select):
+            select = None
+        for project in self.charm_projects.values():
+            if (select is None or
+                    project.launchpad_project in select or
+                    project.charmhub_name in select):
+                yield project

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -56,6 +56,7 @@ try:
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 
+from . import osci_sync
 from .group_config import GroupConfig
 from .launchpadtools import (
     LaunchpadTools,
@@ -694,6 +695,8 @@ def parse_args(argv: Optional[List[str]],
         'validate-config',
         help='Validate the configuration according to the schema.')
     validate_config_commands.set_defaults(func=validate_config_main)
+
+    osci_sync.setup_parser(subparser)
 
     # finally, parse the args and return them.
     args = parser.parse_args(argv)

--- a/charmhub_lp_tools/osci_sync.py
+++ b/charmhub_lp_tools/osci_sync.py
@@ -1,0 +1,223 @@
+# Copyright 2023 Canonical
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+import pathlib
+import sys
+
+from typing import (
+    Any,
+    Dict,
+    List,
+)
+
+import git
+import yaml
+
+from .charm_project import (
+    DEFAULT_RECIPE_FORMAT,
+)
+from .constants import (
+    LIST_AUTO_BUILD_CHANNELS,
+    OSCI_YAML,
+)
+from .exceptions import (
+    BranchNotFound,
+    CharmNameNotFound,
+)
+from .gitutils import (
+    get_branch_name,
+)
+from .group_config import GroupConfig
+from .parsers import (
+    parse_channel,
+)
+
+
+OsciYamlType = List[Any]
+logger = logging.getLogger(__name__)
+
+
+def find_osci_yaml(git_repo: git.Repo) -> pathlib.Path:
+    """Find the osci.yaml file path.
+
+    :param git_repo: git repo of the charm
+    :return: The path to the osci.yaml file.
+    :raise FileNotFoundError: when no osci.yaml was found in the expected
+                              location
+    """
+    git_root = git_repo.git.rev_parse('--show-toplevel')
+    fpath = os.path.join(git_root, OSCI_YAML)
+    if os.path.isfile(fpath):
+        return pathlib.Path(fpath)
+    else:
+        raise FileNotFoundError(fpath)
+
+
+def load_osci_yaml(git_repo: git.Repo) -> OsciYamlType:
+    """Load osci.yaml content into memory.
+
+    :param git_repo: git repo of the charm
+    :return: parsed content of osci.yaml
+    """
+    fpath = find_osci_yaml(git_repo)
+    with open(fpath, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def get_charm_name(osci: OsciYamlType) -> str:
+    """Get the charm name defined in osci.yaml
+
+    :param osci: the osci configuration set in the repo.
+    :returns: the charm name
+    """
+    try:
+        vars_ = get_project_vars(osci)
+        return vars_['charm_build_name']
+    except (TypeError, KeyError) as ex:
+        logger.warning('charm_build_name not found in osci.yaml: %s' % ex)
+        raise CharmNameNotFound()
+    raise CharmNameNotFound()
+
+
+def get_project_vars(osci: OsciYamlType) -> Dict[str, Any]:
+    """Get 'vars' section from osci.yaml.
+
+    :param osci: the osci configuration set in the repo.
+    :returns: vars section
+    """
+    for section in osci:
+        if 'project' not in section:
+            continue
+
+        return section['project']['vars']
+
+
+def update_auto_build_channel_if_needed(auto_build_channels: Dict[str, Any],
+                                        lp_key: str,
+                                        project_vars: Dict[str, Any],
+                                        osci_key: str,
+                                        default: str = None):
+    """Update the auto build channel if needed.
+
+    :param auto_build_channels: dictionary with the auto build channels that
+                                needs to be updated.
+    :param lp_key: the name of the Launchpad auto build channel to update.
+    :param project_vars: the project vars declared in osci.yaml
+    :param osci_key: the name of the osci.yaml build channel to read the value
+                     from.
+    :param default: default value in case the osci_key is not present in
+                    project_vars
+    :returns: True if the auto_build_channels was updated, otherwise False.
+    """
+    new_value = project_vars.get(osci_key, default)
+    if auto_build_channels.get(lp_key) != new_value:
+        logger.info('Updating %s channel from %s to %s',
+                    lp_key,
+                    auto_build_channels.get(lp_key),
+                    new_value)
+        auto_build_channels[lp_key] = new_value
+        return True
+    else:
+        logger.debug('auto build channel %s has not changed', lp_key)
+
+    return False
+
+
+def setup_parser(subparser: argparse.ArgumentParser):
+    parser = subparser.add_parser(
+        'osci-sync',
+        help='Sync the config defined in osci.yaml to Launchpad.',
+    )
+    parser.add_argument(
+        '--i-really-mean-it',
+        dest='i_really_mean_it',
+        action='store_true',
+        default=False,
+        help=('This flag must be supplied to indicate that the sync/apply '
+              'command really should be used.'),
+    )
+    parser.add_argument(
+        '--repo-dir',
+        dest='repo_dir',
+        default=os.getcwd(),
+        metavar='DIR',
+        help=('Path to the git repository where the charm is located at, by '
+              'default it uses the current working directory.'),
+    )
+    parser.set_defaults(func=main)
+    return parser
+
+
+def main(args: argparse.Namespace,
+         gc: GroupConfig,
+         ) -> None:
+    logger.setLevel(getattr(logging, args.loglevel, 'ERROR'))
+    git_repo = git.Repo(args.repo_dir, search_parent_directories=True)
+    osci = load_osci_yaml(git_repo)
+    branch_name = get_branch_name(git_repo)
+    charm_name = get_charm_name(osci)
+    project_vars = get_project_vars(osci)
+    if not list(gc.projects(select=[charm_name])):
+        logger.error("No charm '%s' found; is the name correct?", charm_name)
+        sys.exit(1)
+
+    charm_project = list(gc.projects(select=[charm_name]))[0]
+    try:
+        branch = charm_project.branches[f'refs/heads/{branch_name}']
+    except KeyError:
+        logger.error("The branch '%s' was not found in %s",
+                     branch_name, charm_project)
+        raise BranchNotFound(charm_project, branch_name)
+
+    logger.debug('channels: %s', branch['channels'])
+    for channel in branch['channels']:
+        (track, risk) = parse_channel(channel)
+        recipe_name = DEFAULT_RECIPE_FORMAT.format(
+            project=charm_project.lp_project.name,
+            branch=branch_name.replace('/', '-'),
+            track=track)
+        recipes = charm_project.lpt.get_charm_recipes(
+            charm_project.lp_team,
+            charm_project.lp_project)
+        try:
+            lp_recipe = [r for r in recipes if r.name == recipe_name][0]
+            logger.info('Using recipe %s', lp_recipe.web_link)
+        except IndexError:
+            logger.error('Recipe %s not found in %s',
+                         recipe_name, charm_project)
+            sys.exit(2)
+
+        auto_build_channels = lp_recipe.auto_build_channels
+        lp_changed = False
+        for lp_key, osci_key, default in LIST_AUTO_BUILD_CHANNELS:
+            if update_auto_build_channel_if_needed(
+                    auto_build_channels,
+                    lp_key,
+                    project_vars,
+                    osci_key,
+                    default):
+                lp_changed = True
+
+        if lp_changed:
+            if args.i_really_mean_it:
+                lp_recipe.auto_build_channels = auto_build_channels
+                lp_recipe.lp_save()
+                logger.info('LP recipe updated successfully.')
+            else:
+                logger.info('Dry-run mode: NOT committing the changes')
+        else:
+            logger.info('Nothing to change.')

--- a/charmhub_lp_tools/osci_sync.py
+++ b/charmhub_lp_tools/osci_sync.py
@@ -220,13 +220,10 @@ def osci_sync(args: argparse.Namespace,
             project=charm_project.lp_project.name,
             branch=branch_name.replace('/', '-'),
             track=track)
-        recipes = charm_project.lpt.get_charm_recipes(
-            charm_project.lp_team,
-            charm_project.lp_project)
         try:
-            lp_recipe = [r for r in recipes if r.name == recipe_name][0]
+            lp_recipe = charm_project.lp_recipes[recipe_name]
             logger.info('Using recipe %s', lp_recipe.web_link)
-        except IndexError:
+        except KeyError:
             logger.error('Recipe %s not found in %s',
                          recipe_name, charm_project)
             # TODO(freyes): handle recipe creation when the recipe was not

--- a/charmhub_lp_tools/tests/fixtures/fake_repo/.gitreview
+++ b/charmhub_lp_tools/tests/fixtures/fake_repo/.gitreview
@@ -1,0 +1,6 @@
+[gerrit]
+host=review.example.com
+port=1234
+project=foo/charm-fake.git
+
+defaultbranch=stable/jammy

--- a/charmhub_lp_tools/tests/fixtures/fake_repo/osci.yaml
+++ b/charmhub_lp_tools/tests/fixtures/fake_repo/osci.yaml
@@ -1,0 +1,6 @@
+- project:
+    vars:
+      needs_charm_build: true
+      charm_build_name: fake
+      build_type: charmcraft
+      charmcraft_channel: 2.0/stable

--- a/charmhub_lp_tools/tests/test_gitutils.py
+++ b/charmhub_lp_tools/tests/test_gitutils.py
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from unittest import mock
+
+from charmhub_lp_tools import gitutils
+from charmhub_lp_tools.exceptions import BranchNotFound
+
+
+class TestGitUtils(unittest.TestCase):
+    def setUp(self):
+        self.fake_repo_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), 'fixtures/fake_repo/'))
+        self.git_repo = mock.MagicMock()
+        self.git_repo.git.rev_parse.return_value = self.fake_repo_path
+
+    def test_get_branch_name(self):
+        self.assertEqual(gitutils.get_branch_name(self.git_repo),
+                         'stable/jammy')
+
+    def test_get_gitreview(self):
+        gitreview = gitutils.get_gitreview(self.git_repo)
+        self.assertEqual(gitreview['gerrit']['host'], 'review.example.com')
+        self.assertEqual(gitreview['gerrit']['port'], '1234')
+        self.assertEqual(gitreview['gerrit']['project'], 'foo/charm-fake.git')
+        self.assertEqual(gitreview['gerrit']['defaultbranch'], 'stable/jammy')
+
+    def test_get_default_branch_name(self):
+        main_branch = mock.MagicMock()
+        main_branch.name = 'main'
+        master_branch = mock.MagicMock()
+        master_branch.name = 'master'
+        jammy_branch = mock.MagicMock()
+        jammy_branch.name = 'stable/jammy'
+
+        self.git_repo.references = [jammy_branch]
+
+        self.assertRaises(BranchNotFound,
+                          gitutils.get_default_branch_name, self.git_repo)
+
+        self.git_repo.references = [master_branch]
+        self.assertEqual(gitutils.get_default_branch_name(self.git_repo),
+                         'master')
+        self.git_repo.references = [main_branch]
+        self.assertEqual(gitutils.get_default_branch_name(self.git_repo),
+                         'main')
+        self.git_repo.references = [main_branch, master_branch]
+        self.assertEqual(gitutils.get_default_branch_name(self.git_repo),
+                         'main')

--- a/charmhub_lp_tools/tests/test_osci_sync.py
+++ b/charmhub_lp_tools/tests/test_osci_sync.py
@@ -83,13 +83,13 @@ class TestOsciSync(unittest.TestCase):
         osci_sync.setup_parser(subparser)
         self.assertIn('osci-sync', subparser.choices)
         self.assertEqual(subparser.choices['osci-sync'].get_default('func'),
-                         osci_sync.main)
+                         osci_sync.osci_sync)
         self.assertIn('--i-really-mean-it',
                       subparser.choices['osci-sync'].format_help())
 
     @mock.patch.object(osci_sync, 'logger')
     @mock.patch('git.Repo')
-    def test_main(self, Repo, logger):
+    def test_osci_sync(self, Repo, logger):
         args = mock.MagicMock()
         args.loglevel = 'DEBUG'
         args.repo_dir = self.fake_repo_path
@@ -110,7 +110,7 @@ class TestOsciSync(unittest.TestCase):
         charm_project.lpt.get_charm_recipes.return_value = recipes
         gc.projects.return_value = [charm_project]
 
-        osci_sync.main(args, gc)
+        osci_sync.osci_sync(args, gc)
         logger.info.assert_any_call('Using recipe %s', recipe.web_link)
         logger.info.assert_any_call(
             'The auto build channels have changed: %s',
@@ -125,7 +125,7 @@ class TestOsciSync(unittest.TestCase):
         recipe.web_link = 'https://example.com/charm-fake/%s' % recipe.name
         recipe.auto_build_channels = {'core18': 'latest/edge'}
         args.i_really_mean_it = True
-        osci_sync.main(args, gc)
+        osci_sync.osci_sync(args, gc)
         self.assertDictEqual(recipe.auto_build_channels,
                              {'core18': 'latest/edge',
                               'charmcraft': '2.0/stable'})
@@ -139,7 +139,7 @@ class TestOsciSync(unittest.TestCase):
                 self.assertEqual(code, 2)
                 raise SystemExit(2)
             sys_exit.side_effect = fake_exit
-            self.assertRaises(SystemExit, osci_sync.main, args, gc)
+            self.assertRaises(SystemExit, osci_sync.osci_sync, args, gc)
             logger.error.assert_any_call('Recipe %s not found in %s',
                                          'charm-fake.stable-jammy.22.04',
                                          charm_project)

--- a/charmhub_lp_tools/tests/test_osci_sync.py
+++ b/charmhub_lp_tools/tests/test_osci_sync.py
@@ -106,8 +106,8 @@ class TestOsciSync(unittest.TestCase):
         recipe.name = 'charm-fake.stable-jammy.22.04'
         recipe.web_link = 'https://example.com/charm-fake/%s' % recipe.name
         recipe.auto_build_channels = {'core18': 'latest/edge'}
-        recipes = [recipe]
-        charm_project.lpt.get_charm_recipes.return_value = recipes
+        recipes = {recipe.name: recipe}
+        charm_project.lp_recipes = recipes
         gc.projects.return_value = [charm_project]
 
         osci_sync.osci_sync(args, gc)
@@ -132,7 +132,7 @@ class TestOsciSync(unittest.TestCase):
         recipe.lp_save.assert_called_with()
 
         # re-run with a missing recipe
-        charm_project.lpt.get_charm_recipes.return_value = []
+        charm_project.lp_recipes = {}
         args.i_really_mean_it = False
         with mock.patch('sys.exit') as sys_exit:
             def fake_exit(code):

--- a/charmhub_lp_tools/tests/test_osci_sync.py
+++ b/charmhub_lp_tools/tests/test_osci_sync.py
@@ -1,0 +1,144 @@
+#
+# Copyright (C) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import pathlib
+import unittest
+
+from unittest import mock
+
+from charmhub_lp_tools import osci_sync
+from charmhub_lp_tools.exceptions import CharmNameNotFound
+
+
+class TestOsciSync(unittest.TestCase):
+    def setUp(self):
+        self.fake_repo_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), 'fixtures/fake_repo/'))
+        self.git_repo = mock.MagicMock()
+        self.git_repo.git.rev_parse.return_value = self.fake_repo_path
+
+    def test_find_osci_yaml(self):
+        self.assertEqual(
+            osci_sync.find_osci_yaml(self.git_repo),
+            pathlib.Path(os.path.join(self.fake_repo_path, 'osci.yaml'))
+        )
+
+    def test_find_osci_yaml_not_found(self):
+        self.git_repo.git.rev_parse.return_value = os.path.join(
+            self.fake_repo_path, '..')
+        self.assertRaises(
+            FileNotFoundError,
+            osci_sync.find_osci_yaml, self.git_repo,
+        )
+
+    def test_load_osci_yaml(self):
+        osci = osci_sync.load_osci_yaml(self.git_repo)
+        self.assertTrue(osci[0]['project']['vars']['needs_charm_build'])
+
+    def test_get_charm_name(self):
+        osci = [{'project': {'vars': {'charm_build_name': 'fake'}}}]
+        self.assertEqual(osci_sync.get_charm_name(osci), 'fake')
+        self.assertRaises(CharmNameNotFound, osci_sync.get_charm_name, [{}])
+        self.assertRaises(CharmNameNotFound, osci_sync.get_charm_name,
+                          [{'project': {}}])
+
+    def test_get_project_vars(self):
+        osci = [{'project': {'vars': {'charm_build_name': 'fake'}}}]
+        self.assertEqual(osci_sync.get_project_vars(osci),
+                         {'charm_build_name': 'fake'})
+
+    def test_update_auto_build_channel_if_needed(self):
+        lp_key = 'charmcraft'
+        auto_build_channels = {lp_key: '1.5/stable',
+                               'core18': 'latest/edge'}
+        osci_key = 'charmcraft_channel'
+        project_vars = {osci_key: '2.1/stable'}
+        changed = osci_sync.update_auto_build_channel_if_needed(
+            auto_build_channels,
+            lp_key,
+            project_vars,
+            osci_key)
+        self.assertTrue(changed)
+        self.assertDictEqual(auto_build_channels,
+                             {lp_key: '2.1/stable',
+                              'core18': 'latest/edge'})
+
+    def test_setup_parser(self):
+        parser = argparse.ArgumentParser(description='Test')
+        subparser = parser.add_subparsers(required=True, dest='cmd')
+        osci_sync.setup_parser(subparser)
+        self.assertIn('osci-sync', subparser.choices)
+        self.assertEqual(subparser.choices['osci-sync'].get_default('func'),
+                         osci_sync.main)
+        self.assertIn('--i-really-mean-it',
+                      subparser.choices['osci-sync'].format_help())
+
+    @mock.patch.object(osci_sync, 'logger')
+    @mock.patch('git.Repo')
+    def test_main(self, Repo, logger):
+        args = mock.MagicMock()
+        args.loglevel = 'DEBUG'
+        args.repo_dir = self.fake_repo_path
+        args.i_really_mean_it = False
+        gc = mock.MagicMock()
+        Repo.return_value = self.git_repo
+
+        charm_project = mock.MagicMock()
+        charm_project.lp_project.name = 'charm-fake'
+        charm_project.branches = {
+            'refs/heads/stable/jammy': {'channels': ['22.04/edge']},
+        }
+        recipe = mock.MagicMock()
+        recipe.name = 'charm-fake.stable-jammy.22.04'
+        recipe.web_link = 'https://example.com/charm-fake/%s' % recipe.name
+        recipe.auto_build_channels = {'core18': 'latest/edge'}
+        recipes = [recipe]
+        charm_project.lpt.get_charm_recipes.return_value = recipes
+        gc.projects.return_value = [charm_project]
+
+        osci_sync.main(args, gc)
+        logger.info.assert_any_call('Using recipe %s', recipe.web_link)
+        logger.info.assert_any_call('Updating %s channel from %s to %s',
+                                    'charmcraft', None, '2.0/stable')
+        logger.info.assert_any_call('Dry-run mode: NOT committing the changes')
+        recipe.lp_save.assert_not_called()
+
+        # re-run with --i-really-mean-it
+        recipe.reset_mock()
+        recipe.name = 'charm-fake.stable-jammy.22.04'
+        recipe.web_link = 'https://example.com/charm-fake/%s' % recipe.name
+        recipe.auto_build_channels = {'core18': 'latest/edge'}
+        args.i_really_mean_it = True
+        osci_sync.main(args, gc)
+        self.assertDictEqual(recipe.auto_build_channels,
+                             {'core18': 'latest/edge',
+                              'charmcraft': '2.0/stable'})
+        recipe.lp_save.assert_called_with()
+
+        # re-run with a missing recipe
+        charm_project.lpt.get_charm_recipes.return_value = []
+        args.i_really_mean_it = False
+        with mock.patch('sys.exit') as sys_exit:
+            def fake_exit(code):
+                self.assertEqual(code, 2)
+                raise SystemExit(2)
+            sys_exit.side_effect = fake_exit
+            self.assertRaises(SystemExit, osci_sync.main, args, gc)
+            logger.error.assert_any_call('Recipe %s not found in %s',
+                                         'charm-fake.stable-jammy.22.04',
+                                         charm_project)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ jinja2-humanize-extension
 requests
 requests-cache
 schema
+GitPython


### PR DESCRIPTION
The osci-sync subcommand updates the LP charm build recipe auto build
channels with the information set in osci.yaml

Usage example:

    charmhub-lp-tool osci-sync --i-really-mean-it

By default the current working directory is used to determine the charm
that will be manipulated by the tool, to use a different path use
`--repo-dir /path/to/charm`.