### PR TITLE
Add --anonymous global flag.

### DIFF
--- a/charmhub_lp_tools/constants.py
+++ b/charmhub_lp_tools/constants.py
@@ -10,3 +10,4 @@ class Risk(Enum):
 
 
 LIST_OF_RISKS = [x.value for x in list(Risk)]
+PROGRAM_NAME = 'openstack-charm-tools'

--- a/charmhub_lp_tools/launchpadtools.py
+++ b/charmhub_lp_tools/launchpadtools.py
@@ -23,6 +23,8 @@ import lazr.restfulclient.resource
 from launchpadlib.uris import lookup_service_root
 from launchpadlib.launchpad import Launchpad
 
+from .constants import PROGRAM_NAME
+
 # All objects returned by launchpadlib are lazr.restfulclient.resource.Entry
 TypeLPObject = lazr.restfulclient.resource.Entry
 
@@ -42,14 +44,24 @@ def setup_logging(loglevel: str) -> None:
 class LaunchpadTools:
     """LaunchpadTools - a helper class to work with launchpadlib."""
 
-    def __init__(self) -> None:
-        """Create a LaunchpadTools object, and login to launchpad."""
-        self.lp = Launchpad.login_with(
-            'openstack-charm-tools',
-            service_root=lookup_service_root('production'),
-            version='devel',
-            credential_save_failed=self.no_credential,
-        )
+    def __init__(self, anonymous: bool = False) -> None:
+        """Create a LaunchpadTools object, and login to launchpad.
+
+        :param anonymous: loging to Launchpad anonymously if true.
+        """
+        if anonymous:
+            self.lp = Launchpad.login_anonymously(
+                PROGRAM_NAME,
+                service_root=lookup_service_root('production'),
+                version='devel'
+            )
+        else:
+            self.lp = Launchpad.login_with(
+                PROGRAM_NAME,
+                service_root=lookup_service_root('production'),
+                version='devel',
+                credential_save_failed=self.no_credential,
+            )
 
     @staticmethod
     def no_credential() -> None:

--- a/charmhub_lp_tools/tests/fixtures/lp-builder-config/awesome.yaml
+++ b/charmhub_lp_tools/tests/fixtures/lp-builder-config/awesome.yaml
@@ -1,0 +1,40 @@
+defaults:
+  team: openstack-charmers
+
+projects:
+  - name: HA Cluster Charm
+    charmhub: hacluster
+    launchpad: charm-hacluster
+    repository: https://opendev.org/openstack/charm-hacluster.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/jammy:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - 2.4/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - 2.0.3/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/bionic:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - 1.1.18/edge
+        bases:
+          - "18.04"

--- a/charmhub_lp_tools/tests/test_main.py
+++ b/charmhub_lp_tools/tests/test_main.py
@@ -1,3 +1,4 @@
+import io
 import os
 import shutil
 import tempfile
@@ -86,3 +87,22 @@ class TestCharmhubReport(BaseTest):
 
         with open(os.path.join(self.tmpdir, 'index.html'), 'r') as f:
             self.assertIn('href="openstack-xena.html"', f.read())
+
+
+class TestMain(BaseTest):
+
+    def setUp(self):
+        self.lp_builder_config = os.path.join(os.path.dirname(__file__),
+                                              'fixtures', 'lp-builder-config')
+
+    def test_help(self):
+        with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+            self.assertRaises(SystemExit, main.main, ['-h'])
+            stdout.seek(0)
+            captured = stdout.getvalue()
+            self.assertIn('Configure launchpad projects for charms', captured)
+
+    @mock.patch.object(main, 'LaunchpadTools')
+    def test_anonymous(self, LaunchpadTools):
+        main.main(['--config-dir', self.lp_builder_config, 'validate-config'])
+        LaunchpadTools.assert_called_with(anonymous=True)


### PR DESCRIPTION
The --anonymous flag makes charmhub-lp-tools to login anonymously, this facilitates the usage of charmhub-lp-tool for operations that don't require privileged access.

In this patch the validate-config makes use of anonymous LP API by default allowing CI jobs integrations easier.