### PR TITLE
Docs linting

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -34,6 +34,7 @@ jobs:
         python-version: ['3.10']
         target:
           - pep8
+          - docs
           # - mypy
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/build/
 
 # PyBuilder
 target/

--- a/charmhub_lp_tools/__init__.py
+++ b/charmhub_lp_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tools to configure and manage repositories and Launchpad builders."""

--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -481,14 +481,13 @@ class CharmProject:
 
     The CharmProject is defined in a yaml file and has the following form:
 
-    name: the human friendly name of the project
-    charmhub: the charmhub store name
-    launchpad: the launchpad project name
-    team: the team who should own the branches and charm recipes
-    repo: a URL to the upstream repository to be mirrored in
-          launchpad
-    branches: a list of branch -> recipe_info mappings for charm recipes on
-            launchpad.
+    - name: the human friendly name of the project
+    - charmhub: the charmhub store name
+    - launchpad: the launchpad project name
+    - team: the team who should own the branches and charm recipes
+    - repo: a URL to the upstream repository to be mirrored in launchpad
+    - branches: a list of branch -> recipe_info mappings for charm recipes on
+      launchpad.
 
     The branch_info dictionary consists of the following keys:
 
@@ -524,49 +523,55 @@ class CharmProject:
     publishes the main branch to the latest/edge channel and the stable
     branch to the latest/stable channel:
 
-    name: Awesome Charm
-    charmhub: awesome
-    launchpad: charm-awesome
-    team: awesome-charmers
-    repo: https://github.com/canonical/charm-awesome-operator
-    branches:
-      main:
-        channels: latest/edge
-      stable:
-        channels: latest/stable
+    .. code:: yaml
+
+      name: Awesome Charm
+      charmhub: awesome
+      launchpad: charm-awesome
+      team: awesome-charmers
+      repo: https://github.com/canonical/charm-awesome-operator
+      branches:
+        main:
+          channels: latest/edge
+        stable:
+          channels: latest/stable
 
     The following example builds a charm using the latest/edge channel of
     charmcraft, and does not upload the results to the store
 
-    name: Awesome Charm
-    charmhub: awesome
-    launchpad: charm-awesome
-    team: awesome-charmers
-    repo: https://github.com/canonical/charm-awesome-operator
-    branches:
-      main:
-        store-upload: False
-        build-channels:
-          charmcraft: latest/edge
+    .. code:: yaml
+
+      name: Awesome Charm
+      charmhub: awesome
+      launchpad: charm-awesome
+      team: awesome-charmers
+      repo: https://github.com/canonical/charm-awesome-operator
+      branches:
+        main:
+          store-upload: False
+          build-channels:
+            charmcraft: latest/edge
 
     The following example builds a charm on the main branch of the git
     repository and publishes the results to the yoga/edge and latest/edge
     channels and builds a charm on the stable/xena branch of the git
     repository and publishes the results to xena/edge.
 
-    name: Awesome Charm
-    charmhub: awesome
-    launchpad: charm-awesome
-    team: awesome-charmers
-    repo: https://github.com/canonical/charm-awesome-operator
-    branches:
-      main:
-        channels:
-          - yoga/edge
-          - latest/edge
-      stable/xena:
-        channels:
-          - xena/edge
+    .. code: yaml
+
+      name: Awesome Charm
+      charmhub: awesome
+      launchpad: charm-awesome
+      team: awesome-charmers
+      repo: https://github.com/canonical/charm-awesome-operator
+      branches:
+        main:
+          channels:
+            - yoga/edge
+            - latest/edge
+        stable/xena:
+          channels:
+            - xena/edge
 
 
     The follow example builds a charm on the main branch of the git repository
@@ -576,23 +581,25 @@ class CharmProject:
     the 20.04 base, and any operations on the xena channel are duplicated to
     the victoria channel (e.g. copy, clean)
 
-    name: Awesome Charm
-    charmhub: awesome
-    launchpad: charm-awesome
-    team: awesome-charmers
-    repo: https://github.com/canonical/charm-awesome-operator
-    branches:
-      main:
-        channels:
-          - yoga/edge
-          - latest/edge
-      stable/xena:
-        channels:
-          - xena/edge
-        bases:
-          - "20.04"
-        duplicate-channels:
-          - victoria
+    .. code:: yaml
+
+      name: Awesome Charm
+      charmhub: awesome
+      launchpad: charm-awesome
+      team: awesome-charmers
+      repo: https://github.com/canonical/charm-awesome-operator
+      branches:
+        main:
+          channels:
+            - yoga/edge
+            - latest/edge
+        stable/xena:
+          channels:
+            - xena/edge
+          bases:
+            - "20.04"
+          duplicate-channels:
+            - victoria
     """
 
     INFO_URL = CHARMHUB_BASE + "/info/{charm}?fields=channel-map"
@@ -651,7 +658,7 @@ class CharmProject:
 
     @property
     def raw_charm_info(self):
-        """Raw charm info as published by charmhub ``/info` endpoint."""
+        """Raw charm info as published by charmhub ``/info`` endpoint."""
         if not self._raw_charm_info:
             self._raw_charm_info = requests.get(
                 self.INFO_URL.format(charm=self.charmhub_name)
@@ -1420,12 +1427,13 @@ class CharmProject:
         """Determine if the build is valid.
 
         A valid build a build that meets the following criteria:
-        - it's associated recipe has the attribute can_upload_to_store set to
+
+        * it's associated recipe has the attribute can_upload_to_store set to
           True, but the build has no store_upload_revision set, and the build
           is not in progress (states: currently build, uploading build or needs
           building)
-        - the build state is in any of: 'Failed to build', 'Failed to upload'.
-        - the associated recipe is stale.
+        * the build state is in any of: 'Failed to build', 'Failed to upload'.
+        * the associated recipe is stale.
 
         :param build: build to check if it is valid.
         :returns: True if the last build is valid.

--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -1,16 +1,17 @@
 # Copyright 2021 Canonical
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Logic to handle charms definitions."""
 
 import collections
 import json
@@ -56,7 +57,7 @@ requests_session = requests_cache.CachedSession(':memory:')
 
 
 def setup_logging(loglevel: str) -> None:
-    """Sets up some basic logging."""
+    """Set up some basic logging."""
     logger.setLevel(getattr(logging, loglevel, 'ERROR'))
 
 
@@ -97,9 +98,10 @@ def run_charmcraft(
 
 
 class CharmChannel:
+    """Abstraction of a charm's channel in Charmhub."""
 
     def __init__(self, project: 'CharmProject', name: str):
-        """Initialse the CharmChannel object
+        """Initialse the CharmChannel object.
 
         :param project: the project that this charm channel is associated with
         :param name: the channel name (track or track/risk)
@@ -125,6 +127,7 @@ class CharmChannel:
 
     @property
     def channel_map(self):
+        """Charmhub channel map."""
         return self.project.charmhub_channel_map
 
     def close(
@@ -648,6 +651,7 @@ class CharmProject:
 
     @property
     def raw_charm_info(self):
+        """Raw charm info as published by charmhub ``/info` endpoint."""
         if not self._raw_charm_info:
             self._raw_charm_info = requests.get(
                 self.INFO_URL.format(charm=self.charmhub_name)
@@ -656,6 +660,7 @@ class CharmProject:
 
     @property
     def charmhub_channel_map(self):
+        """Charmhub channel map."""
         try:
             self.raw_charm_info.encoding = 'utf-8'
             m = json.loads(self.raw_charm_info.text.strip())
@@ -687,6 +692,7 @@ class CharmProject:
 
     @property
     def channels(self) -> Set[CharmChannel]:
+        """List of channels declared by this charm."""
         if not self._channels:
             self._channels = set()
             for value in self.branches.values():
@@ -697,6 +703,7 @@ class CharmProject:
 
     @property
     def tracks(self) -> Set[str]:
+        """List of tracks declared by this charm."""
         return set([c.track for c in self.channels])
 
     @property
@@ -1172,8 +1179,7 @@ class CharmProject:
     def show_lauchpad_config(self,
                              file: IO = sys.stdout
                              ) -> None:
-        """Print out the launchpad config for the charms, if any.
-        """
+        """Print out the launchpad config for the charms, if any."""
         logger.info(f'Printing launchpad info for: {self.name}')
         try:
             self.lp_project

--- a/charmhub_lp_tools/charmhub.py
+++ b/charmhub_lp_tools/charmhub.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Tools to work with the charmhub.
+"""Tools to work with the charmhub."""
 
 
 import logging
@@ -31,11 +30,12 @@ _charmhub_client: Optional[httpbakery.Client] = None
 
 
 def setup_logging(loglevel: str) -> None:
-    """Sets up some basic logging."""
+    """Set up some basic logging."""
     logger.setLevel(getattr(logging, loglevel, 'ERROR'))
 
 
 def get_charmhub_client() -> httpbakery.Client:
+    """Get a Charmhub API client object."""
     global _charmhub_client
     if _charmhub_client is None:
         _charmhub_client = httpbakery.Client()
@@ -64,12 +64,18 @@ def authorize_from_macaroon_dict(auth_data: Dict) -> str:
 
 
 class CharmhubConfig:
+    """Charmhub configuration."""
+
     api_url = "https://api.charmhub.io"
     storage_url = "https://storage.snapcraftcontent.com"
     registry_url = "https://registry.jujucharms.com"
 
 
-def get_store_client():
+def get_store_client() -> store.Store:
+    """Get Charmhub store API client.
+
+    :returns: a Store instance logged in to Charmhub.
+    """
     config = CharmhubConfig()
     mystore = store.Store(config)
 

--- a/charmhub_lp_tools/constants.py
+++ b/charmhub_lp_tools/constants.py
@@ -1,8 +1,24 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants used across the program."""
+
 from enum import Enum
 
 
 class Risk(Enum):
     """Charmhub risk levels."""
+
     EDGE = 'edge'
     BETA = 'beta'
     CANDIDATE = 'candidate'

--- a/charmhub_lp_tools/exceptions.py
+++ b/charmhub_lp_tools/exceptions.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Charmhub LP Tools error classes."""
+
+
 class CharmcraftError504(Exception):
     """charmcraft failed with a error 504 from charmhub."""
 

--- a/charmhub_lp_tools/gitutils.py
+++ b/charmhub_lp_tools/gitutils.py
@@ -13,6 +13,7 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Helpers to manipulate git repositories."""
 
 import configparser
 import logging

--- a/charmhub_lp_tools/group_config.py
+++ b/charmhub_lp_tools/group_config.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Logic to manage groups of charms as defined in lp-builder-config."""
 
 import collections
 import logging
@@ -115,7 +116,7 @@ class GroupConfig:
 
     def projects(self, select: Optional[List[str]] = None,
                  ) -> Iterator[CharmProject]:
-        """Generator returns a list of projects."""
+        """Generate a list of projects."""
         if not (select):
             select = None
         for project in self.charm_projects.values():

--- a/charmhub_lp_tools/launchpadtools.py
+++ b/charmhub_lp_tools/launchpadtools.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Logic to handle Launchpad API objects."""
 
 import logging
 import functools
@@ -37,7 +38,7 @@ except AttributeError:
 
 
 def setup_logging(loglevel: str) -> None:
-    """Sets up some basic logging."""
+    """Set up some basic logging."""
     logger.setLevel(getattr(logging, loglevel, 'ERROR'))
 
 
@@ -65,6 +66,7 @@ class LaunchpadTools:
 
     @staticmethod
     def no_credential() -> None:
+        """Event handler when LP credentials could not be saved."""
         logging.error("Couldn't save/store the Launchpad credential")
         sys.exit(1)
 
@@ -100,8 +102,7 @@ class LaunchpadTools:
             owner: TypeLPObject,
             project: TypeLPObject
     ) -> TypeLPObject:
-        """Returns the reference to the Launchpad git repository by owner and
-        project.
+        """Get the reference to the LP git repository by owner and project.
 
         Return the first reference to a Launchpad git repository which is
         owned by the specified owner for the given project. If multiple
@@ -127,8 +128,10 @@ class LaunchpadTools:
                           project: TypeLPObject,
                           url: str
                           ) -> TypeLPObject:
-        """Creates a repository in Launchpad imported from the specified url
-        belonging to the specified owner and project.
+        """Create a repository in Launchpad imported from the specified url.
+
+        The object created is associated to the specified ``owner`` and
+        ``project``.
 
         :param owner: the owner of the repository
         :type owner: a launchpad team
@@ -137,6 +140,7 @@ class LaunchpadTools:
         :param url: the url to the repository to import from
         :type url: str
         :returns: the reference to the Launchpad git repository
+
         """
         logger.info('Importing git repository from %s into project '
                     '%s for user %s',
@@ -160,8 +164,7 @@ class LaunchpadTools:
                           owner: TypeLPObject,
                           project: TypeLPObject
                           ) -> List[TypeLPObject]:
-        """Returns charm recipes for the specified owner in the specified
-        project.
+        """Get charm recipes for the specified owner in the specified project.
 
         Returns all charm recipes owned by the specified owner for the given
         project. Note, this is necessary as Launchpad does not have an API
@@ -191,12 +194,14 @@ class LaunchpadTools:
             store_channels: Optional[List[str]] = None,
             store_upload: bool = False,
     ) -> bool:
-        """Updates the charm_recipe to match the requested configuration in
-        the track_info.
+        """Update the charm_recipe.
+
+        The update is made to match the requested configuration in the
+        ``branch_info``.
 
         :param recipe: the charm recipe to update
         :param branch_info: the branch_info dictionary containing information
-                           for the recipe
+                            for the recipe
         :return: True if updated, False otherwise
         """
         changed, updated_dict, changes = self.diff_charm_recipe(
@@ -227,7 +232,7 @@ class LaunchpadTools:
             store_channels: Optional[List[str]] = None,
             store_upload: bool = False,
     ) -> Tuple[bool, Dict[str, Any], List[str]]:
-        """Returns Updates the charm_recipe to match the required config.
+        """Get the updates the charm_recipe needs to match the required config.
 
         :param recipe: the charm recipe to update
         :param branch_info: the branch_info dictionary containing information

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -118,18 +118,18 @@ def get_file_config() -> FileConfig:
         ignore_errors=bool(config_items.get('ignore_errors', False)))
 
 
-def check_config_dir_exists(dir_: pathlib.Path) -> pathlib.Path:
-    """Validate that the config dir_ exists.
+def check_config_dir_exists(dirpath: pathlib.Path) -> pathlib.Path:
+    """Validate that the config dirpath exists.
 
     Raises FileNotFoundError if it doesn't.
 
-    :param dir_: the config path that needs to exist.
+    :param dirpath: the config path that needs to exist.
     :raises: FileNotFoundError if the configuration directory doesn't exist.
     """
-    if not dir_.exists():
+    if not dirpath.exists():
         raise FileNotFoundError(
-            f'Configuration directory "{dir_}" does not exist')
-    return dir_
+            f'Configuration directory "{dirpath}" does not exist')
+    return dirpath
 
 
 def get_group_config_filenames(config_dir: pathlib.Path,
@@ -138,7 +138,7 @@ def get_group_config_filenames(config_dir: pathlib.Path,
                                ) -> List[pathlib.Path]:
     """Fetch the list of files for the group config.
 
-    Depending on whether :param:`project_group_names` is passed, get the list
+    Depending on whether ``project_group_names`` is passed, get the list
     of files that contain the projects that need configuring.
 
     :param config_dir: the directory to look in
@@ -871,7 +871,7 @@ def request_code_import(args: argparse.Namespace,
     """Request a code import on Launchpad.
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     for cp in gc.projects(select=args.charms):
         cp.request_code_import(dry_run=not args.confirmed)
@@ -884,7 +884,7 @@ def copy_channel(args: argparse.Namespace,
     """Copy the charms released from a channel to another one.
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     :returns: a dictionary of charm name -> revisions released.
     """
     cp_revs = {}
@@ -931,7 +931,7 @@ def ch_report_main(args: argparse.Namespace,
     """Generate report of published charms.
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     klass = get_charmhub_report_klass(args.format)
     report = klass(args.output)
@@ -968,7 +968,7 @@ def clean_channel(args: argparse.Namespace,
     """Clean a channel by keeping charm revisions specified by bases.
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     for cp in gc.projects(select=args.charms):
         src_channel = CharmChannel(cp, args.src_channel)
@@ -996,7 +996,7 @@ def copy_revisions(args: argparse.Namespace,
     then the command will fail:
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     assert args.from_risk != args.to_risk, "Can't copy from/to same risk"
     for cp in gc.projects(select=args.charms):
@@ -1024,7 +1024,7 @@ def close_channel(args: argparse.Namespace,
     (although note that there is a clean-channel command for that purpose).
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     for cp in gc.projects(select=args.charms):
         try:
@@ -1055,7 +1055,7 @@ def repair_resource(args: argparse.Namespace,
     that case it'll need to be done manually.
 
     :param args: the arguments parsed from the command line.
-    :para gc: The GroupConfig; i.e. all the charms and their config.
+    :param gc: The GroupConfig; i.e. all the charms and their config.
     """
     for cp in gc.projects(select=args.charms):
         if '/' in args.channel:

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -1,18 +1,16 @@
 # Copyright 2021 Canonical
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 """Tools to configure and manage repositories and launchpad builders.
 
 This file contains a command that provides the ability to configure and manage
@@ -82,6 +80,8 @@ NOW = datetime.now(tz=ZoneInfo("UTC"))
 
 
 class FileConfig(NamedTuple):
+    """Holds configuration information."""
+
     config_dir: Optional[str] = None
     log_level: Optional[str] = None
     ignore_errors: bool = False
@@ -1077,7 +1077,7 @@ def repair_resource(args: argparse.Namespace,
 def validate_config_main(args: argparse.Namespace,
                          gc: GroupConfig,
                          ):
-    """Validate configuration files based on the schema"""
+    """Validate configuration files based on the schema."""
     # This subcommand is a NOOP, if the execution reached to this point it
     # means the configuration was loaded successfully and validated correctly
     # by the schema, so there is no need do anything else than inform the user
@@ -1086,7 +1086,7 @@ def validate_config_main(args: argparse.Namespace,
 
 
 def setup_logging(loglevel: str) -> None:
-    """Sets up some basic logging."""
+    """Set up some basic logging."""
     logging.basicConfig(format=LOGGING_FORMAT)
     logger.setLevel(getattr(logging, loglevel, 'ERROR'))
     cp_setup_logging(loglevel)
@@ -1095,7 +1095,7 @@ def setup_logging(loglevel: str) -> None:
 
 
 def main(argv: Optional[List[str]] = None):
-    """Main entry point.
+    """Provide the main entry point.
 
     :param argv: The list of command line arguments to parse.
     """

--- a/charmhub_lp_tools/osci_sync.py
+++ b/charmhub_lp_tools/osci_sync.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Logic behince the ``osci-sync`` subcommand."""
 
 import argparse
 import logging
@@ -57,8 +58,7 @@ logger = logging.getLogger(__name__)
 
 def diff_auto_build_channels(lp_auto_build_channels: Dict[str, str],
                              local_auto_build_channels: Dict[str, str]):
-    """
-    Obtain the differences between auto build channels maps.
+    """Obtain the differences between auto build channels maps.
 
     The differences are obtained using the symmetic difference operation from
     sets.
@@ -167,6 +167,7 @@ def gen_auto_build_channel(auto_build_channels: Dict[str, Any],
 
 
 def setup_parser(subparser: argparse.ArgumentParser):
+    """Set up arguments parser for the CLI."""
     parser = subparser.add_parser(
         'osci-sync',
         help='Sync the config defined in osci.yaml to Launchpad.',
@@ -194,6 +195,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
 def osci_sync(args: argparse.Namespace,
               gc: GroupConfig,
               ) -> None:
+    """Provide the main entry point for the ``osci-sync`` subcommand."""
     logger.setLevel(getattr(logging, args.loglevel, 'ERROR'))
     git_repo = git.Repo(args.repo_dir, search_parent_directories=True)
     osci = load_osci_yaml(git_repo)

--- a/charmhub_lp_tools/parsers.py
+++ b/charmhub_lp_tools/parsers.py
@@ -1,3 +1,18 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers to parse different strings with known formats."""
+
 from typing import Tuple
 
 from charmhub_lp_tools.constants import (

--- a/charmhub_lp_tools/schema.py
+++ b/charmhub_lp_tools/schema.py
@@ -1,3 +1,18 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Schema definition for lp-builder-config."""
+
 from schema import (
     Optional,
     Regex,

--- a/charmhub_lp_tools/templates/__init__.py
+++ b/charmhub_lp_tools/templates/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module to store the templates used by the reports module."""

--- a/charmhub_lp_tools/tests/__init__.py
+++ b/charmhub_lp_tools/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module to test charmhub_lp_tools."""

--- a/charmhub_lp_tools/tests/base.py
+++ b/charmhub_lp_tools/tests/base.py
@@ -1,3 +1,18 @@
+# Copyright 2023 Canonical
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Base classes for testing."""
+
 import json
 import os
 import unittest
@@ -28,7 +43,10 @@ CHARM_CONFIG = yaml.safe_load(CHARM_CONFIG_STR)
 
 
 class BaseTest(unittest.TestCase):
+    """Base class for test cases."""
+
     def setUp(self):
+        """Set up base class."""
         self.lpt = mock.MagicMock()
         self.project = charm_project.CharmProject(CHARM_CONFIG, self.lpt)
         self.project._charmhub_tracks = ['yoga', 'latest', 'xena']

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-paramlinks

--- a/doc/source/charm_project.rst
+++ b/doc/source/charm_project.rst
@@ -1,0 +1,7 @@
+The :mod:`charmhub_lp_tools.charm_project` Module
+-------------------------------------------------
+
+.. automodule:: charmhub_lp_tools.charm_project
+   :noindex:
+   :members:
+   :show-inheritance:

--- a/doc/source/charmhub.rst
+++ b/doc/source/charmhub.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.charmhub` Module
+--------------------------------------------
+
+.. automodule:: charmhub_lp_tools.charmhub
+   :members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,65 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#  nova documentation build configuration file
+#
+# Refer to the Sphinx documentation for advice on configuring this file:
+#
+#   http://www.sphinx-doc.org/en/stable/config.html
+
+import os
+import sys
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath('../../'))
+
+# -- General configuration ----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.todo',
+    'sphinx_paramlinks',
+]
+
+todo_include_todos = True
+
+# The parameter name is a clickable hyperlink.
+paramlinks_hyperlink_param='name'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+copyright = u'2023-present, Canonical'
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'native'
+
+# -- Options for HTML output --------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  Major themes that come with
+# Sphinx are currently 'default' and 'sphinxdoc'.
+html_theme = 'default'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# Add any paths that contain "extra" files, such as .htaccess or
+# robots.txt.
+html_extra_path = ['_extra']

--- a/doc/source/constants.rst
+++ b/doc/source/constants.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.constants` Module
+---------------------------------------------
+
+.. automodule:: charmhub_lp_tools.constants
+   :members:

--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.exceptions` Module
+----------------------------------------------
+
+.. automodule:: charmhub_lp_tools.exceptions
+   :members:

--- a/doc/source/gitutils.rst
+++ b/doc/source/gitutils.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.gitutils` Module
+--------------------------------------------
+
+.. automodule:: charmhub_lp_tools.gitutils
+   :members:

--- a/doc/source/group_config.rst
+++ b/doc/source/group_config.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.group_config` Module
+------------------------------------------------
+
+.. automodule:: charmhub_lp_tools.group_config
+   :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,16 @@
+
+.. toctree::
+   :maxdepth: 1
+
+   charmhub
+   charm_project
+   constants
+   exceptions
+   gitutils
+   group_config
+   launchpadtools
+   main
+   osci_sync
+   parsers
+   reports
+   schema

--- a/doc/source/launchpadtools.rst
+++ b/doc/source/launchpadtools.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.launchpadtools` Module
+--------------------------------------------------
+
+.. automodule:: charmhub_lp_tools.launchpadtools
+   :members:

--- a/doc/source/main.rst
+++ b/doc/source/main.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.main` Module
+----------------------------------------
+
+.. automodule:: charmhub_lp_tools.main
+   :members:

--- a/doc/source/osci_sync.rst
+++ b/doc/source/osci_sync.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.osci_sync` Module
+---------------------------------------------
+
+.. automodule:: charmhub_lp_tools.osci_sync
+   :members:

--- a/doc/source/parsers.rst
+++ b/doc/source/parsers.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.parsers` Module
+--------------------------------------------
+
+.. automodule:: charmhub_lp_tools.parsers
+   :members:

--- a/doc/source/reports.rst
+++ b/doc/source/reports.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.reports` Module
+-------------------------------------------
+
+.. automodule:: charmhub_lp_tools.reports
+   :members:

--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -1,0 +1,5 @@
+The :mod:`charmhub_lp_tools.schema` Module
+------------------------------------------
+
+.. automodule:: charmhub_lp_tools.schema
+   :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ packages = charmhub_lp_tools
 [entry_points]
 console_scripts =
     charmhub-lp-tool = charmhub_lp_tools.main:cli_main
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 flake8
+pydocstyle
 mypy
 pytest
 requests-mock

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,9 @@ basepython = python3
 deps =
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-commands = flake8 charmhub_lp_tools {posargs}
+commands =
+    flake8 charmhub_lp_tools {posargs}
+    pydocstyle charmhub_lp_tools
 
 [testenv:mypy]
 basepython = python3
@@ -53,3 +55,11 @@ commands = {posargs}
 [flake8]
 ignore = E402,E226,W504
 exclude = */charmhelpers
+
+[pydocstyle]
+# D105 Missing docstring in magic method (reason: magic methods already have definitions)
+# D107 Missing docstring in __init__ (reason: documented in class docstring)
+# D203 1 blank line required before class docstring (reason: pep257 default)
+# D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
+# D215 Section underline is over-indented (reason: pep257 default)
+ignore = D105, D107, D203, D213, D215

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ python =
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          CHARM_DIR={envdir}
+allowlist_externals =
+  /bin/rm
 install_command =
   pip install {opts} {packages}
 
@@ -43,6 +45,18 @@ deps =
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
 commands = mypy charmhub_lp_tools {posargs}
+
+[testenv:docs]
+description =
+  Build main documentation.
+# Note that we don't use {[testenv]deps} for deps here because we don't want
+# to install (test-)requirements.txt for docs.
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/doc/requirements.txt
+commands =
+  /bin/rm -rf doc/build/html doc/build/doctrees
+  sphinx-build --keep-going -b html -j auto doc/source doc/build/html
 
 [testenv:venv]
 basepython = python3


### PR DESCRIPTION
This PR introduces 2 new tools for linting purposes:

- pydocstyle, the good and old known tool to check compliance with conventions. The list of rules to ignore was borrowed from charmcraft project, I found it sensible to start with it.
- sphinx, the use of this tool more than to publish documentation is meant to detect broken docstring formatting and keep them in shape.