### PR TITLE
Print a summary of the project series created.

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -795,10 +795,10 @@ class CharmProject:
                     series = self.create_series(series_name,
                                                 branch_info['series-summary'],
                                                 dry_run)
+                    created_series[series_name] = series
                     if not dry_run and series:
                         self.log.info('New created series %s (%s)',
                                       series.name, series.web_link)
-                        created_series[series_name] = series
                 else:
                     series = self.lp_series[series_name]
 
@@ -836,6 +836,7 @@ class CharmProject:
         if dry_run:
             self.log.info(('NOT creating the series %s with summary %s '
                            '(dry-run mode)'), name, summary)
+            return None
         else:
             return self.lpt.create_project_series(self.lp_project,
                                                   name=name, summary=summary)

--- a/charmhub_lp_tools/tests/test_ensure_series.py
+++ b/charmhub_lp_tools/tests/test_ensure_series.py
@@ -55,3 +55,29 @@ class TestEnsureSeries(BaseTest):
 
         charm_project.ensure_series.assert_called_with(branches=git_branches,
                                                        dry_run=True)
+
+    def test_print_summary(self):
+        cp = mock.MagicMock()
+        cp.charmhub_name = 'foobar'
+        zed_series = mock.MagicMock()
+        zed_series.web_link = 'http://example.com/zed'
+        with mock.patch('builtins.print') as print:
+            ensure_series.print_summary(cp, {'zed': None}, dry_run=True)
+            print.assert_has_calls(
+                [
+                    mock.call(
+                        'Series that would have been created for charm foobar'
+                    ),
+                    mock.call('    zed: (dry-run)'),
+                ]
+            )
+        with mock.patch('builtins.print') as print:
+            ensure_series.print_summary(cp, {'zed': zed_series}, dry_run=False)
+            print.assert_has_calls(
+                [
+                    mock.call(
+                        'Series created for charm foobar'
+                    ),
+                    mock.call('    zed: %s' % zed_series.web_link),
+                ]
+            )


### PR DESCRIPTION
Currently the `ensure-series` command only logs what it's doing without
printing information to the user of what it did (it would have done),
this becomes a problem when the use runs the program with the log level
set to WARNING or ERROR.

Output example:

    Series created for charm OpenStack Manila Generic Charm
        train: https://launchpad.net/charm-manila-generic/train
        ussuri: https://launchpad.net/charm-manila-generic/ussuri
        victoria: https://launchpad.net/charm-manila-generic/victoria
        wallaby: https://launchpad.net/charm-manila-generic/wallaby
        xena: https://launchpad.net/charm-manila-generic/xena
        yoga: https://launchpad.net/charm-manila-generic/yoga
        zed: https://launchpad.net/charm-manila-generic/zed