### PR TITLE
Report improvements

### DIFF
--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -832,7 +832,11 @@ def check_builds_main(args: argparse.Namespace,
     klass = get_builds_report_klass(args.format)
     build_report = klass(args.output)
     for cp in gc.projects(select=args.charms):
-        for (recipe, build) in cp.get_builds(set(args.channels), args.arch_tag,
+        if args.channels:
+            channels = set(args.channels)
+        else:
+            channels = set([c.name for c in cp.channels])
+        for (recipe, build) in cp.get_builds(channels, args.arch_tag,
                                              args.detect_error):
             build_report.add_build(cp, recipe, build)
 


### PR DESCRIPTION
These patches allow the report generation without having to explicitly request a set of tracks and channels on the command line, this reduces the maintenance on automated report generation.

- fed23f7 charmhub-report: make list of tracks optional.
- 9fa386f Fix check-builds when no channel is passed to filter.