### PR TITLE
Update copy-revisions to not clobber older versions

### DIFF
--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -642,6 +642,15 @@ def parse_args(argv: Optional[List[str]],
         default=3,
         help='Retry calls when charmhub issues a 504 error',
     )
+    copy_revisions_command.add_argument(
+        '--force',
+        dest='force',
+        action='store_true',
+        default=False,
+        help=('If this flag is used, older (lower value) revisions will be '
+              'copied even if a younger (higher value) revision already '
+              'exists for that arch/base combination.')
+    )
     copy_revisions_command.set_defaults(func=copy_revisions)
 
     # repair resources
@@ -1020,7 +1029,8 @@ def copy_revisions(args: argparse.Namespace,
             cp.copy_revisions(channel=src_channel,
                               to_risk=args.to_risk,
                               dry_run=not args.confirmed,
-                              retries=args.retries)
+                              retries=args.retries,
+                              force=args.force)
         except Exception as e:
             logger.info("Couldn't copy revision for: %s", cp.charmhub_name)
             logger.error("Exception %s", str(e))

--- a/charmhub_lp_tools/tests/test_charm_project.py
+++ b/charmhub_lp_tools/tests/test_charm_project.py
@@ -182,12 +182,12 @@ class TestCharmChannel(BaseTest):
                                                        'yoga/stable')
             self.assertEqual(charm_channel
                              .get_revisions_for_bases(bases=['22.04']),
-                             {79})
+                             [79])
             charm_channel = charm_project.CharmChannel(self.project,
                                                        'latest/edge')
             self.assertEqual(charm_channel
                              .get_revisions_for_bases(bases=['22.04']),
-                             {96, 93, 94, 95})
+                             [93, 94, 95, 96])
 
     @mock.patch('charmhub_lp_tools.charm_project.get_store_client')
     def test_release(self, get_store_client):

--- a/tox.ini
+++ b/tox.ini
@@ -71,8 +71,10 @@ commands = {posargs}
 basepython = python3
 deps =
      -r{toxinidir}/requirements.txt
+setenv =
+    PIP_USE_PEP517=1
 commands =
-  python3 -m pip --use-pep517 install ./
+  python3 -m pip install ./
   /bin/rm -rf {temp_dir}/charmed-openstack-info
   /usr/bin/git clone https://github.com/openstack-charmers/charmed-openstack-info.git {temp_dir}/charmed-openstack-info
   charmhub-lp-tool --log DEBUG --anonymous --config-dir {temp_dir}/charmed-openstack-info/charmed_openstack_info/data/lp-builder-config validate-config

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ deps =
 setenv =
     PIP_USE_PEP517=1
 commands =
-  python3 -m pip --use-pep517 install ./
+  python3 -m pip install ./
   /bin/rm -rf {temp_dir}/charmed-openstack-info
   /usr/bin/git clone https://github.com/openstack-charmers/charmed-openstack-info.git {temp_dir}/charmed-openstack-info
   charmhub-lp-tool --log DEBUG --anonymous --config-dir {temp_dir}/charmed-openstack-info/charmed_openstack_info/data/lp-builder-config validate-config

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ allowlist_externals =
   /bin/rm
   /usr/bin/git
 install_command =
-  pip install {opts} {packages}
+  pip install --use-pep517 {opts} {packages}
 
 [testenv:py3]
 basepython = python3
@@ -72,7 +72,7 @@ basepython = python3
 deps =
      -r{toxinidir}/requirements.txt
 commands =
-  python3 -m pip install ./
+  python3 -m pip --use-pep517 install ./
   /bin/rm -rf {temp_dir}/charmed-openstack-info
   /usr/bin/git clone https://github.com/openstack-charmers/charmed-openstack-info.git {temp_dir}/charmed-openstack-info
   charmhub-lp-tool --log DEBUG --anonymous --config-dir {temp_dir}/charmed-openstack-info/charmed_openstack_info/data/lp-builder-config validate-config


### PR DESCRIPTION
When copying revisions using the copy-revision subcommand, the patch checks that the revisions that will be copied are not older (less than) the revisions existing in the target risk.  A force option is added to allow overriding of the check.