### PR TITLE
Move upload error message to build log column.

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -669,7 +669,7 @@ class CharmProject:
     def _add_branches(self, branches_spec: Dict[str, Dict]) -> None:
         for branch, branch_info in branches_spec.items():
             ref = f'refs/heads/{branch}'
-            if type(branch_info) != dict:
+            if not isinstance(branch_info, dict):
                 raise ValueError(f'{self.charmhub_name}\n'
                                  f'Expected a dict for key branches, '
                                  f' instead got {type(branch_info)} - '

--- a/charmhub_lp_tools/reports.py
+++ b/charmhub_lp_tools/reports.py
@@ -175,6 +175,9 @@ class PlainBuildsReport(BaseBuildsReport):
         series_arch = f'{build.distro_series.name}/{build_arch_tag}'
         if build.buildstate != 'Successfully built':
             build_log = build.build_log_url
+        elif (build.buildstate == 'Successfully built' and
+              build.store_upload_revision):
+            build_log = build.store_upload_error_message
         else:
             build_log = ''
 
@@ -186,7 +189,7 @@ class PlainBuildsReport(BaseBuildsReport):
                            build.revision_id)
             revision = None
 
-        if build.store_upload_status == 'Uploaded':
+        if build.store_upload_revision:
             store_rev = build.store_upload_revision
         else:
             store_rev = build.store_upload_error_message


### PR DESCRIPTION
There are scenarios where Launchpad could have uploaded the built charm
and a revision number assigned, but it failed to be released, the most
common reason to fail to release is the missing resource attached to the
Ubuntu series set the charm runs on.

This change makes sure the store revision is included in the report and
the upload error message displayed in the "build log" column.

Test case:

```
charmhub-lp-tool -c swift-proxy check-builds --channel latest/edge
```

Without this patch:

```
+---------------------------------+-------------+-------------+--------------------+--------------+----------+---------------------------------------------------------------------------------------------------------------------------+-----------+
| Recipe Name                     | Channels    | Arch        | State              | Age          | Revision | Store Rev                                                                                                                 | Build Log |
+---------------------------------+-------------+-------------+--------------------+--------------+----------+---------------------------------------------------------------------------------------------------------------------------+-----------+
| charm-swift-proxy.master.latest | latest/edge | jammy/amd64 | Successfully built | 18 hours ago | 4e5659b  | Resource 'policyd-override' missing from this 'swift-proxy' release or any previously released revisions on channel: edge |           |
+---------------------------------+-------------+-------------+--------------------+--------------+----------+---------------------------------------------------------------------------------------------------------------------------+-----------+
```

With this patch:

```
+---------------------------------+-------------+-------------+--------------------+--------------+----------+-----------+---------------------------------------------------------------------------------------------------------------------------+
| Recipe Name                     | Channels    | Arch        | State              | Age          | Revision | Store Rev | Build Log                                                                                                                 |
+---------------------------------+-------------+-------------+--------------------+--------------+----------+-----------+---------------------------------------------------------------------------------------------------------------------------+
| charm-swift-proxy.master.latest | latest/edge | jammy/amd64 | Successfully built | 23 hours ago | 4e5659b  | 162       | Resource 'policyd-override' missing from this 'swift-proxy' release or any previously released revisions on channel: edge |
+---------------------------------+-------------+-------------+--------------------+--------------+----------+-----------+---------------------------------------------------------------------------------------------------------------------------+
```