### PR TITLE
Snapcraft uses SNAPCRAFT_STORE_CREDENTIALS env variable now

### DIFF
--- a/.github/workflows/snapcraft.yaml
+++ b/.github/workflows/snapcraft.yaml
@@ -20,8 +20,9 @@ jobs:
     - id: publish
       if: github.ref == 'refs/heads/main'
       uses: snapcore/action-publish@v1
-      with:
+      env:
         # See: https://github.com/snapcore/action-publish#store-login
-        store_login: ${{ secrets.STORE_LOGIN }}
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
         snap: ${{ steps.build.outputs.snap }}
         release: edge


### PR DESCRIPTION
The snapcraft tool relies on the environment variable SNAPCRAFT_STORE_CREDENTIALS to get the credentials, the '--with' argument no longer works.

This change updates the gh action to use the env variable.