### PR TITLE
Add 'print-revisions' command

### DIFF
--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -19,8 +19,7 @@ import itertools
 import logging
 import subprocess
 import tempfile
-from typing import (Any, Dict, Generator, List, Tuple, IO, Optional, Set,
-                    Union)
+from typing import (Any, Dict, Generator, List, Tuple, IO, Optional, Set)
 import sys
 import time
 import yaml
@@ -465,11 +464,6 @@ class CharmChannel:
                 if delete:
                     del revisions_[all_arch]
         return revisions_
-        # now just keep the highest revision for each arch.
-        highest_revisions: Dict[str, int] = {}
-        for k, v in revisions_.items():
-            highest_revisions[k] = list(sorted(v))[-1]
-        return highest_revisions
 
     def get_revisions_for_bases_by_arch(
         self,
@@ -1864,7 +1858,7 @@ class CharmProject:
                 CharmChannel.str_revisions_by_arch(destination_arch_revisions))
 
             # don't duplicate releases to the same channel.
-            revision_pairs: Set[Tuple[int, Union[int, None]]] = set()
+            revision_pairs: Set[Tuple[int, Optional[int]]] = set()
             for arch, revision in arch_revisions.items():
                 dest_revision = destination_arch_revisions.get(arch)
                 if (revision, dest_revision) in revision_pairs:

--- a/charmhub_lp_tools/charm_project.py
+++ b/charmhub_lp_tools/charm_project.py
@@ -19,7 +19,8 @@ import itertools
 import logging
 import subprocess
 import tempfile
-from typing import (Any, Dict, Generator, List, Tuple, IO, Optional, Set)
+from typing import (Any, Dict, Generator, List, Tuple, IO, Optional, Set,
+                    Union)
 import sys
 import time
 import yaml
@@ -1863,7 +1864,7 @@ class CharmProject:
                 CharmChannel.str_revisions_by_arch(destination_arch_revisions))
 
             # don't duplicate releases to the same channel.
-            revision_pairs: Set[Tuple[int, int | None]] = set()
+            revision_pairs: Set[Tuple[int, Union[int, None]]] = set()
             for arch, revision in arch_revisions.items():
                 dest_revision = destination_arch_revisions.get(arch)
                 if (revision, dest_revision) in revision_pairs:

--- a/charmhub_lp_tools/main.py
+++ b/charmhub_lp_tools/main.py
@@ -56,6 +56,7 @@ except ImportError:
 
 from . import ensure_series
 from . import osci_sync
+from . import revisions
 from .group_config import GroupConfig
 from .launchpadtools import (
     LaunchpadTools,
@@ -707,6 +708,7 @@ def parse_args(argv: Optional[List[str]],
 
     osci_sync.setup_parser(subparser)
     ensure_series.setup_parser(subparser)
+    revisions.setup_parser(subparser)
 
     # finally, parse the args and return them.
     args = parser.parse_args(argv)

--- a/charmhub_lp_tools/revisions.py
+++ b/charmhub_lp_tools/revisions.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     List,
     Set,
+    Union,
 )
 
 from prettytable import PrettyTable
@@ -94,8 +95,8 @@ def setup_parser(
 
 
 def get_revisions(channel: CharmChannel,
-                  args_bases: List[str] | None,
-                  args_arches: List[str] | None
+                  args_bases: Union[List[str], None],
+                  args_arches: Union[List[str], None],
                   ) -> Dict[str, Dict[str, List[int]]]:
     """Get the revisions by base -> arch -> [revisions].
 

--- a/charmhub_lp_tools/revisions.py
+++ b/charmhub_lp_tools/revisions.py
@@ -72,7 +72,6 @@ def setup_parser(
     parser.add_argument(
         '--format',
         dest='format',
-        # choices=('table', 'json', 'html'),
         choices=('table', 'json', 'rst'),
         default='table',
         type=str.lower,
@@ -100,8 +99,8 @@ def get_revisions(channel: CharmChannel,
     """Get the revisions by base -> arch -> [revisions].
 
     :param channel: the charm channel to work against.
-    :param bases: Optional list of bases to restrict report to.
-    :param arches: Optional list of arches to restrict report to.
+    :param args_bases: Optional list of bases to restrict report to.
+    :param args_arches: Optional list of arches to restrict report to.
     :returns: a mapping of base -> arch -> List of revisions
     """
     revisions: Dict[str, Dict[str, Set[int]]] = {}

--- a/charmhub_lp_tools/revisions.py
+++ b/charmhub_lp_tools/revisions.py
@@ -20,7 +20,6 @@ import os
 import pathlib
 import textwrap
 from typing import (
-    Any,
     Dict,
     List,
     Set,
@@ -179,7 +178,7 @@ def format_as_rst(
         channel: CharmChannel,
         results: Dict[str, Dict[str, List[int]]],
         indent_level: int = 0) -> str:
-    """Format the output as an ReST table (sphinx)
+    """Format the output as an ReST table (sphinx).
 
     This produces the table element with a group tab and then the included
     rows.
@@ -187,7 +186,7 @@ def format_as_rst(
     :param results: the results to format into a table.
     :returns: the formatted string
     """
-    rst_channel = format_channel_as_rst(results,indent_level=indent_level + 1)
+    rst_channel = format_channel_as_rst(results, indent_level=indent_level + 1)
     if not rst_channel:
         return ""
     return "\n".join([
@@ -200,7 +199,7 @@ def format_as_rst(
 def format_channel_as_rst(
         results: Dict[str, Dict[str, List[int]]],
         indent_level: int = 0) -> str:
-    """Format the output as an ReST table (sphinx)
+    """Format the output as an ReST table (sphinx).
 
     This produces the table element; it'll need a header and group tabs created
     by another section.
@@ -232,19 +231,19 @@ def format_channel_as_rst(
     return "\n".join(output)
 
 
-def format_rst_tabs(indent_level: int=0) -> str:
+def format_rst_tabs(indent_level: int = 0) -> str:
     """Return the grouptab for an RST table.
 
     :returns: a string of lines, indented, for the tabs.
     """
     return textwrap.indent(
         "\n".join([
-            f'.. tabs::',
+            '.. tabs::',
             '',
         ]), '   ' * indent_level)
 
 
-def format_rst_grouptab(header: str, indent_level: int=0) -> str:
+def format_rst_grouptab(header: str, indent_level: int = 0) -> str:
     """Return the grouptab for an RST table.
 
     :param header: the string to put in the header.
@@ -257,7 +256,7 @@ def format_rst_grouptab(header: str, indent_level: int=0) -> str:
         ]), '   ' * indent_level)
 
 
-def format_rst_header(indent_level: int=0, num_cols=None) -> str:
+def format_rst_header(indent_level: int = 0, num_cols=None) -> str:
     """Return the header for rst table.
 
     :param indent_level: how var (*3 spaces) to indent this header.
@@ -290,7 +289,6 @@ def format_rst_row(columns: List[str],
     :param indent_level: the level (*3 space) to indent the section.
     :returns: a string of lines, indented, for the row.
     """
-
     try:
         lines: List[str] = ["* - {}".format(columns[0])]
     except IndexError:
@@ -304,18 +302,18 @@ def format_rst_row(columns: List[str],
             lines.append(f"{prefix}- {empty_column}")
         prefix = "  "
     lines.append('')
-    lines = [l.rstrip() for l in lines]
+    lines = [line.rstrip() for line in lines]
     return textwrap.indent("\n".join(lines), '   ' * indent_level)
 
 
 def format_as_html(channel: CharmChannel,
-                    results: Dict[str, Dict[str, List[int]]]) -> str:
+                   results: Dict[str, Dict[str, List[int]]]) -> str:
     """Format the output as a HTML page.
 
     :param results: the results to format into a table.
     :returns: the formatted string
     """
-    raise NotImplemented("HTML reports aren't implemented yet.")
+    raise NotImplementedError("HTML reports aren't implemented yet.")
 
 
 def print_revisions(

--- a/charmhub_lp_tools/revisions.py
+++ b/charmhub_lp_tools/revisions.py
@@ -1,0 +1,364 @@
+# Copyright 2023 Canonical
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Implement the print-revisions command."""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import textwrap
+from typing import (
+    Any,
+    Dict,
+    List,
+    Set,
+)
+
+from prettytable import PrettyTable
+
+from .charm_project import (
+    CharmChannel,
+)
+
+from .group_config import GroupConfig
+from .parsers import (
+    parse_channel,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def setup_parser(
+    subparser: argparse.ArgumentParser
+) -> argparse.ArgumentParser:
+    """Setup parser for print-revisions command."""
+    parser = subparser.add_parser(
+        'print-revisions',
+        help=('Print all the revisions for a base, arch, channel or any '
+              'combination thereof.'),
+    )
+    parser.add_argument(
+        '-s', '--channel',
+        dest='channel',
+        metavar='CHANNEL',
+        required=True,
+        help='The channel as track/risk to clean.',
+    )
+    parser.add_argument(
+        '-b', '--base',
+        dest='bases',
+        action='append',
+        type=str,
+        help='Restrict to a particular base. Can be repeated.')
+    parser.add_argument(
+        '-a', '--arch',
+        dest='arches',
+        action='append',
+        type=str,
+        help='Restrict to a particular arch. Can be repeated.')
+    parser.add_argument(
+        '--format',
+        dest='format',
+        # choices=('table', 'json', 'html'),
+        choices=('table', 'json', 'rst'),
+        default='table',
+        type=str.lower,
+        help=('The format to output the report in. default is "table"'))
+    parser.add_argument(
+        '--tab-size',
+        dest='tab_size',
+        default=5,
+        type=int,
+        help=('The number of tabs in a tab group for RST format. Ignored for'
+              'other formats.'))
+    parser.add_argument(
+        '-o', '--out',
+        dest='output',
+        help=('Write the output to a file.  Default is STDOUT'))
+
+    parser.set_defaults(func=print_revisions)
+    return parser
+
+
+def get_revisions(channel: CharmChannel,
+                  args_bases: List[str] | None,
+                  args_arches: List[str] | None
+                  ) -> Dict[str, Dict[str, List[int]]]:
+    """Get the revisions by base -> arch -> [revisions].
+
+    :param channel: the charm channel to work against.
+    :param bases: Optional list of bases to restrict report to.
+    :param arches: Optional list of arches to restrict report to.
+    :returns: a mapping of base -> arch -> List of revisions
+    """
+    revisions: Dict[str, Dict[str, Set[int]]] = {}
+    logger.debug("channel:  %s", channel)
+    logger.debug("bases: %s", channel.bases)
+    bases = sorted(set(channel.bases) & set(args_bases or channel.bases))
+    logger.debug("selected bases: %s", bases)
+    # now get the revisions for each of the bases found; in theory these
+    # groups of revisions will be in 'increasing' numbers if they are
+    # released for the charm.  It will also have to be done by architecture
+    # as those may have different revision numbers.
+    for base in bases:
+        logger.debug("Looking at base %s", base)
+        revisions[base] = channel.get_all_revisions_for_bases_by_arch(
+            [base])
+    logger.debug("All revisions found: %s", revisions)
+    # now sort the revisions into base -> arch -> revision.  The arch is in
+    # the form of '<arch>/<base>' and <arch> can be all.
+    # First extract all the arches.
+    arches_set: Set[str] = set(arch.split('/')[0]
+                               for arch_revisions in revisions.values()
+                               for arch in arch_revisions.keys())
+    logger.debug("Architectures set: %s", arches_set)
+    arches = sorted(arches_set & set(args_arches or arches_set))
+    logger.debug("Filtered archectectures: %s", arches)
+    # now assemble the resultant data.
+    results: Dict[str, Dict[str, List[int]]] = {}
+    for base in bases:
+        results[base] = {}
+        keys = revisions[base].keys()
+        for arch in arches:
+            for k in keys:
+                if k.split('/')[0] == arch:
+                    results[base][arch] = sorted(revisions[base][k])
+    return results
+
+
+def format_as_table(channel: CharmChannel,
+                    results: Dict[str, Dict[str, List[int]]]) -> str:
+    """Format the output as a PrettyTable.
+
+    Note that the table is in the form:
+
+          : base1 : base2 : ...
+    arch1 : r1    : r1    : ...
+    arch2 : r3    : r2    : ...
+
+    i.e. bases across, arches down.
+
+    :param results: the results to format into a table.
+    :returns: the formatted string
+    """
+    bases = list(results.keys())
+    if not bases:
+        return ""
+    t = PrettyTable()
+    arch_headings = sorted(
+        set(arch for arches in results.values() for arch in arches.keys()))
+    t.field_names = [''] + bases
+    t.align = 'l'  # align to the left.
+    t.title = f'Charm: {channel.project.charmhub_name} - Track: {channel.name}'
+    for arch_heading in arch_headings:
+        row = [arch_heading]
+        for base, arches in results.items():
+            try:
+                row.append(", ".join(str(a) for a in arches[arch_heading]))
+            except KeyError:
+                row.append("-")
+        t.add_row(row)
+    return t.get_string()
+
+
+def format_as_rst(
+        channel: CharmChannel,
+        results: Dict[str, Dict[str, List[int]]],
+        indent_level: int = 0) -> str:
+    """Format the output as an ReST table (sphinx)
+
+    This produces the table element with a group tab and then the included
+    rows.
+
+    :param results: the results to format into a table.
+    :returns: the formatted string
+    """
+    rst_channel = format_channel_as_rst(results,indent_level=indent_level + 1)
+    if not rst_channel:
+        return ""
+    return "\n".join([
+        format_rst_grouptab(channel.project.charmhub_name,
+                            indent_level=indent_level),
+        rst_channel
+    ])
+
+
+def format_channel_as_rst(
+        results: Dict[str, Dict[str, List[int]]],
+        indent_level: int = 0) -> str:
+    """Format the output as an ReST table (sphinx)
+
+    This produces the table element; it'll need a header and group tabs created
+    by another section.
+
+    :param results: the results to format into a table.
+    :returns: the formatted string
+    """
+    bases = list(results.keys())
+    if not bases:
+        return ""
+    output: List[str] = [format_rst_header(indent_level,
+                                           num_cols=len(bases) + 1)]
+    # add the header.
+    arch_headings = sorted(
+        set(arch for arches in results.values() for arch in arches.keys()))
+    output.append(format_rst_row([''] + bases,
+                                 len(bases) + 1,
+                                 indent_level=indent_level + 1))
+    for arch_heading in arch_headings:
+        row = [arch_heading]
+        for base, arches in results.items():
+            try:
+                row.append(", ".join(str(a) for a in arches[arch_heading]))
+            except KeyError:
+                row.append('-')
+        output.append(format_rst_row(row,
+                                     len(row),
+                                     indent_level=indent_level+1))
+    return "\n".join(output)
+
+
+def format_rst_tabs(indent_level: int=0) -> str:
+    """Return the grouptab for an RST table.
+
+    :returns: a string of lines, indented, for the tabs.
+    """
+    return textwrap.indent(
+        "\n".join([
+            f'.. tabs::',
+            '',
+        ]), '   ' * indent_level)
+
+
+def format_rst_grouptab(header: str, indent_level: int=0) -> str:
+    """Return the grouptab for an RST table.
+
+    :param header: the string to put in the header.
+    :returns: a string of lines, indented, for the grouptab.
+    """
+    return textwrap.indent(
+        "\n".join([
+            f'.. group-tab:: {header}',
+            '',
+        ]), '   ' * indent_level)
+
+
+def format_rst_header(indent_level: int=0, num_cols=None) -> str:
+    """Return the header for rst table.
+
+    :param indent_level: how var (*3 spaces) to indent this header.
+    :returns: a string of lines, indented, for the header.
+    """
+    if num_cols:
+        widths = " ".join("1" * num_cols)
+    else:
+        widths = "auto"
+    return textwrap.indent(
+        "\n".join([
+            '.. list-table::',
+            '   :header-rows: 1',
+            '   :widths: {}'.format(widths),
+            '   :width: 75%',
+            '   :stub-columns: 0',
+            '',
+        ]), '   ' * indent_level)
+
+
+def format_rst_row(columns: List[str],
+                   row_size: int,
+                   empty_column: str = "",
+                   indent_level: int = 0) -> str:
+    """Format an rst row using columns.
+
+    :param columns: a list of strings, one for each column.
+    :param num_columns: the number of columns to populate.
+    :param empty_column: the string to use for an empty column
+    :param indent_level: the level (*3 space) to indent the section.
+    :returns: a string of lines, indented, for the row.
+    """
+
+    try:
+        lines: List[str] = ["* - {}".format(columns[0])]
+    except IndexError:
+        lines: List[str] = ["* - {}".format(empty_column)]
+    lines: List[str] = []
+    prefix = "* "
+    for row in range(0, row_size):
+        try:
+            lines.append(f"{prefix}- {columns[row]}")
+        except IndexError:
+            lines.append(f"{prefix}- {empty_column}")
+        prefix = "  "
+    lines.append('')
+    lines = [l.rstrip() for l in lines]
+    return textwrap.indent("\n".join(lines), '   ' * indent_level)
+
+
+def format_as_html(channel: CharmChannel,
+                    results: Dict[str, Dict[str, List[int]]]) -> str:
+    """Format the output as a HTML page.
+
+    :param results: the results to format into a table.
+    :returns: the formatted string
+    """
+    raise NotImplemented("HTML reports aren't implemented yet.")
+
+
+def print_revisions(
+    args: argparse.Namespace,
+    gc: GroupConfig,
+) -> None:
+    """Entry point for the 'print-revisions' command."""
+    logger.setLevel(getattr(logging, args.loglevel, 'ERROR'))
+    track, risk = None, None
+    try:
+        track, risk = parse_channel(args.channel)
+    except ValueError as e:
+        logger.error(f"Malformed channel: {args.channel}: {e}")
+        return
+    output: List[str] = []
+
+    for cp in gc.projects(select=args.charms):
+        logger.debug("working with project: %s", cp)
+        channel = CharmChannel(cp, args.channel)
+        results = get_revisions(channel, args.bases, args.arches)
+        if args.format == "table":
+            output.append(format_as_table(channel, results))
+        elif args.format == "json":
+            output.append(json.dumps(results, indent=2))
+        elif args.format == "rst":
+            if (formatted := format_as_rst(channel, results, indent_level=1)):
+                output.append(formatted)
+                continue
+        else:
+            raise RuntimeError(
+                f"Passed '{args.format}' which shouldn't be possible.")
+
+    # if rst formatting then add tabs at args.tab_size increments.
+    if args.format == 'rst':
+        all_output = [format_rst_tabs()]
+        for i, table in enumerate(output):
+            if i > 0 and args.tab_size and (i % args.tab_size) == 0:
+                all_output.append(format_rst_tabs())
+            all_output.append(table)
+        output = all_output
+
+    if args.output:
+        os.makedirs(pathlib.Path(args.output).parent, exist_ok=True)
+        with open(args.output, "wt") as f:
+            f.write("\n".join(output))
+    else:
+        print("\n".join(output))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ theblues
 libcharmstore
 launchpadlib
 prettytable
-humanize<4.0.0  # newer versions of humanize are incompatible with jinja2-humanize-extension
+# humanize<4.0.0  # newer versions of humanize are incompatible with jinja2-humanize-extension
+humanize
 backports.zoneinfo; python_version < '3.9'
 SecretStorage  # LP: #1923727
 macaroonbakery

--- a/tox.ini
+++ b/tox.ini
@@ -89,4 +89,4 @@ exclude = */charmhelpers
 # D203 1 blank line required before class docstring (reason: pep257 default)
 # D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
 # D215 Section underline is over-indented (reason: pep257 default)
-ignore = D105, D107, D203, D213, D215
+ignore = D105, D107, D203, D213, D215, D401


### PR DESCRIPTION
The 'print-revisions' command prints out a set or revision numbers for
projects from charmed-openstack-info. The can be filtered according to
bases, channels and architectures. This is handy to find a set of
revisions that supports a particular base/arch in a channel.
